### PR TITLE
Logging connection string change

### DIFF
--- a/Logging/SFA.DAS.NLog.Targets.AzureEventHub/AzureEventHubTarget.cs
+++ b/Logging/SFA.DAS.NLog.Targets.AzureEventHub/AzureEventHubTarget.cs
@@ -27,7 +27,6 @@ namespace SFA.DAS.NLog.Targets.AzureEventHub
         /// Obsolete - use EventHubConnectionStringKey
         /// </summary>
         [Obsolete("Use EventHubConnectionStringKey")]
-        [RequiredParameter]
         public string EventHubConnectionString { get; set; }
 
         /// <summary>
@@ -36,9 +35,16 @@ namespace SFA.DAS.NLog.Targets.AzureEventHub
         [RequiredParameter]
         public string EventHubConnectionStringKey { get; set; }
 
-        [RequiredParameter]
+        [Obsolete("Use EventHubNameKey")]
         public string EventHubName { get; set; }
 
+        /// <summary>
+        /// Points to the app config setting that contains the EventHubName. This uses CloudConfiguration.GetSetting which falls back to use Appsetting if not presents
+        /// </summary>
+        [RequiredParameter]
+        public string EventHubNameKey { get; set; }
+
+        [RequiredParameter]
         public string PartitionKey { get; set; }
 
         protected override void Write(AsyncLogEventInfo logEvent)
@@ -68,7 +74,11 @@ namespace SFA.DAS.NLog.Targets.AzureEventHub
 
             if (_eventHubClient == null)
             {
-                _eventHubClient = _messsagingFactory.CreateEventHubClient(EventHubName);
+                var eventHubName = !string.IsNullOrWhiteSpace(CloudConfigurationManager.GetSetting(EventHubNameKey)) 
+                                    ? CloudConfigurationManager.GetSetting(EventHubNameKey)
+                                    : EventHubName;
+
+                _eventHubClient = _messsagingFactory.CreateEventHubClient(eventHubName);
             }
 
             var payload = FormPayload(logEvents.Select(e => e.LogEvent), partitionKey);

--- a/Logging/SFA.DAS.NLog.Targets.AzureEventHub/AzureEventHubTarget.cs
+++ b/Logging/SFA.DAS.NLog.Targets.AzureEventHub/AzureEventHubTarget.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using System.Text;
+using Microsoft.Azure;
 using Microsoft.ServiceBus;
 using Microsoft.ServiceBus.Messaging;
 using Newtonsoft.Json;
@@ -21,8 +23,18 @@ namespace SFA.DAS.NLog.Targets.AzureEventHub
         [RequiredParameter]
         public string AppName { get; set; }
 
+        /// <summary>
+        /// Obsolete - use EventHubConnectionStringKey
+        /// </summary>
+        [Obsolete("Use EventHubConnectionStringKey")]
         [RequiredParameter]
         public string EventHubConnectionString { get; set; }
+
+        /// <summary>
+        /// Points to the app config setting that contains the EventHubConnectionString. This uses CloudConfiguration.GetSetting which falls back to use Appsetting if not presents
+        /// </summary>
+        [RequiredParameter]
+        public string EventHubConnectionStringKey { get; set; }
 
         [RequiredParameter]
         public string EventHubName { get; set; }
@@ -43,7 +55,15 @@ namespace SFA.DAS.NLog.Targets.AzureEventHub
         {
             if (_messsagingFactory == null)
             {
-                _messsagingFactory = MessagingFactory.CreateFromConnectionString(EventHubConnectionString);
+                if (!string.IsNullOrWhiteSpace(EventHubConnectionStringKey))
+                {
+                    _messsagingFactory = MessagingFactory.CreateFromConnectionString(CloudConfigurationManager.GetSetting(EventHubConnectionStringKey));
+                }
+                else
+                {
+                    _messsagingFactory = MessagingFactory.CreateFromConnectionString(EventHubConnectionString);
+                }
+                
             }
 
             if (_eventHubClient == null)

--- a/Logging/SFA.DAS.NLog.Targets.AzureEventHub/AzureEventHubTarget.cs
+++ b/Logging/SFA.DAS.NLog.Targets.AzureEventHub/AzureEventHubTarget.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using System.Text;
 using Microsoft.Azure;
-using Microsoft.ServiceBus;
 using Microsoft.ServiceBus.Messaging;
 using Newtonsoft.Json;
 using NLog;
@@ -22,22 +20,13 @@ namespace SFA.DAS.NLog.Targets.AzureEventHub
 
         [RequiredParameter]
         public string AppName { get; set; }
-
-        /// <summary>
-        /// Obsolete - use EventHubConnectionStringKey
-        /// </summary>
-        [Obsolete("Use EventHubConnectionStringKey")]
-        public string EventHubConnectionString { get; set; }
-
+        
         /// <summary>
         /// Points to the app config setting that contains the EventHubConnectionString. This uses CloudConfiguration.GetSetting which falls back to use Appsetting if not presents
         /// </summary>
         [RequiredParameter]
         public string EventHubConnectionStringKey { get; set; }
-
-        [Obsolete("Use EventHubNameKey")]
-        public string EventHubName { get; set; }
-
+        
         /// <summary>
         /// Points to the app config setting that contains the EventHubName. This uses CloudConfiguration.GetSetting which falls back to use Appsetting if not presents
         /// </summary>
@@ -61,24 +50,12 @@ namespace SFA.DAS.NLog.Targets.AzureEventHub
         {
             if (_messsagingFactory == null)
             {
-                if (!string.IsNullOrWhiteSpace(EventHubConnectionStringKey))
-                {
-                    _messsagingFactory = MessagingFactory.CreateFromConnectionString(CloudConfigurationManager.GetSetting(EventHubConnectionStringKey));
-                }
-                else
-                {
-                    _messsagingFactory = MessagingFactory.CreateFromConnectionString(EventHubConnectionString);
-                }
-                
+                _messsagingFactory = MessagingFactory.CreateFromConnectionString(CloudConfigurationManager.GetSetting(EventHubConnectionStringKey));
             }
 
             if (_eventHubClient == null)
             {
-                var eventHubName = !string.IsNullOrWhiteSpace(CloudConfigurationManager.GetSetting(EventHubNameKey)) 
-                                    ? CloudConfigurationManager.GetSetting(EventHubNameKey)
-                                    : EventHubName;
-
-                _eventHubClient = _messsagingFactory.CreateEventHubClient(eventHubName);
+                _eventHubClient = _messsagingFactory.CreateEventHubClient(CloudConfigurationManager.GetSetting(EventHubNameKey));
             }
 
             var payload = FormPayload(logEvents.Select(e => e.LogEvent), partitionKey);

--- a/Logging/SFA.DAS.NLog.Targets.AzureEventHub/SFA.DAS.NLog.Targets.AzureEventHub.csproj
+++ b/Logging/SFA.DAS.NLog.Targets.AzureEventHub/SFA.DAS.NLog.Targets.AzureEventHub.csproj
@@ -34,6 +34,10 @@
       <HintPath>..\packages\WindowsAzure.ServiceBus.3.3.2\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.1\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/Logging/SFA.DAS.NLog.Targets.AzureEventHub/SFA.DAS.NLog.Targets.AzureEventHub.nuspec
+++ b/Logging/SFA.DAS.NLog.Targets.AzureEventHub/SFA.DAS.NLog.Targets.AzureEventHub.nuspec
@@ -14,6 +14,7 @@
             <group targetFramework=".NETFramework4.5">
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
                 <dependency id="WindowsAzure.ServiceBus" version="3.3.2" />
+                <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" />
                 <dependency id="NLog" version="4.3.7" />
             </group>
         </dependencies>

--- a/Logging/SFA.DAS.NLog.Targets.AzureEventHub/packages.config
+++ b/Logging/SFA.DAS.NLog.Targets.AzureEventHub/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FAKEBuildScript" version="1.0.12" targetFramework="net452" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NLog" version="4.3.7" targetFramework="net452" />
   <package id="NuGet.CommandLine" version="3.3.0" targetFramework="net452" />

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ The target has the following configuration format:
           name="String"
           appName="String"
           layout="Layout"
-          eventHubConnectionString="String"
-          eventHubName="String">
+          eventHubConnectionStringKey="String"
+          eventHubNameKey="String">
   </target>
 </targets>
 ```
@@ -120,17 +120,23 @@ The target has the following configuration format:
 * _layout_ - (Optional) Layout that should be used to calculate the value for the **message** field. [Layout](https://github.com/nlog/nlog/wiki/Layouts)
 * _eventHubConnectionString_ - Azure Event Hub connection string. [String](String)
 * _eventHubName_ - Event Hub Name. [String](String)
-
+* _eventHubConnectionStringKey_ The app setting key that should be used to for the Connection string [String](String)
+ _eventHubNameKey_ - The app setting key that should be used for the Event Hub Name. [String](String)
 
 ### Example
 ```xml
+<appSettings>
+	<add key="EventHubName" value="Event hub name"/>
+	<add key="EventHubConnectionString" value="Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=<sas name>;SharedAccessKey=<sas key>;TransportType=Amqp"/>
+</appSettings>
+
 <targets>
   <target xsi:type="AzureEventHub"
           name="eventHubLogger"
           appName="MyTestApplication"
           layout="${message}"
-          eventHubConnectionString="Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=<sas name>;SharedAccessKey=<sas key>;TransportType=Amqp"
-          eventHubName="test-hub">
+          eventHubConnectionStringKey="EventHubConnectionString"
+          eventHubNameKey="EventHubName">
   </target>
 </targets>
 ```


### PR DESCRIPTION
Made a change so that the configuration settings for the EventHub logging are read from app setting keys instead of from the config directly. I haven't removed the old parameters but have taken off the RequiredParameter attribute and marked as obsolete in the code