### PR TITLE
Oidc middleware updates for ids

### DIFF
--- a/SFA.DAS.OidcMiddleware/SFA.DAS.Oidc.Middleware.TestSite/Startup.cs
+++ b/SFA.DAS.OidcMiddleware/SFA.DAS.Oidc.Middleware.TestSite/Startup.cs
@@ -1,6 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens;
+using System.Linq;
 using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using Microsoft.Owin;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
@@ -36,7 +40,21 @@ namespace SFA.DAS.Oidc.Middleware.TestSite
                 TokenEndpoint = Constants.TokenEndpoint,
                 UserInfoEndpoint = Constants.UserInfoEndpoint,
                 AuthorizeEndpoint = Constants.AuthorizeEndpoint,
-                AuthenticatedCallback = identity => { identity.AddClaim(new Claim("CustomClaim", "new claim added")); }
+                AuthenticatedCallback = identity =>
+                {
+                    identity.AddClaim(new Claim("CustomClaim", "new claim added"));
+
+                    // This can be used to translate claims to known identifiers for the OTB ASP.NET MVC Template
+                    //identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, identity.Claims.First(c => c.Type == "user_id").Value));
+                    //identity.AddClaim(new Claim(ClaimTypes.Name, identity.Claims.First(c => c.Type == "display_name").Value));
+                },
+                TokenValidationMethod = TokenValidationMethod.BinarySecret,
+
+                // Implement this if TokenValidationMethod = TokenValidationMethod.SigningKey
+                //TokenSigningCertificateLoader = () =>
+                //{
+                //    return new X509Certificate2(@"[PATH_TO_YOUR_PFX]", "[YOUR_PFX_PASSWORD]");
+                //}
             });
         }
     }

--- a/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/OidcMiddlewareOptions.cs
+++ b/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/OidcMiddlewareOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.DataHandler;
 
@@ -25,5 +26,7 @@ namespace SFA.DAS.OidcMiddleware
         public string BaseUrl { get; set; }
         public string UserInfoEndpoint { get; set; }
         public Action<ClaimsIdentity> AuthenticatedCallback { get; set; }
+        public TokenValidationMethod TokenValidationMethod { get; set; } = TokenValidationMethod.BinarySecret;
+        public Func<X509Certificate2> TokenSigningCertificateLoader { get; set; }
     }
 }

--- a/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware.csproj
+++ b/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Strategies\AuthenticateCoreStrategy.cs" />
     <Compile Include="Strategies\IApplyResponseChallengeStrategy.cs" />
     <Compile Include="Strategies\IAuthenticateCoreStrategy.cs" />
+    <Compile Include="TokenValidationMethod.cs" />
     <Compile Include="Validators\ISecurityTokenValidation.cs" />
     <Compile Include="Validators\SecurityTokenValidation.cs" />
   </ItemGroup>

--- a/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware.nuspec
+++ b/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>SFA.DAS.OidcMiddleware</id>
-        <version>1.0.0</version>
+        <version>2.0.0</version>
         <authors>DAS</authors>
         <owners>DAS</owners>
         <licenseUrl>https://github.com/SkillsFundingAgency/das-shared-packages/blob/master/LICENSE</licenseUrl>

--- a/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/Strategies/AuthenticateCoreStrategy.cs
+++ b/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/Strategies/AuthenticateCoreStrategy.cs
@@ -71,13 +71,13 @@ namespace SFA.DAS.OidcMiddleware.Strategies
         {
             if (!string.IsNullOrWhiteSpace(response.IdentityToken))
             {
-                var tokenClaims = _securityTokenValidation.ValidateToken(response.IdentityToken, nonce);
-                var claims = new List<Claim>();
+                var claims = _securityTokenValidation.ValidateToken(response.IdentityToken, nonce);
 
                 if (!string.IsNullOrWhiteSpace(response.AccessToken))
                 {
                     claims.AddRange(await _buildUserInfoClient.GetUserClaims(_options, response.AccessToken));
-                    claims.Add(new Claim(ClaimTypes.Name, claims.First(c => c.Type == "name").Value));
+                    //TODO: Check this is not used. Should be added in authentication callback
+                    //claims.Add(new Claim(ClaimTypes.Name, claims.First(c => c.Type == "name").Value));
                     claims.Add(new Claim("access_token", response.AccessToken));
                     claims.Add(new Claim("expires_at", (DateTime.UtcNow.ToEpochTime() + response.ExpiresIn).ToDateTimeFromEpoch().ToString()));
                 }

--- a/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/Strategies/AuthenticateCoreStrategy.cs
+++ b/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/Strategies/AuthenticateCoreStrategy.cs
@@ -76,8 +76,6 @@ namespace SFA.DAS.OidcMiddleware.Strategies
                 if (!string.IsNullOrWhiteSpace(response.AccessToken))
                 {
                     claims.AddRange(await _buildUserInfoClient.GetUserClaims(_options, response.AccessToken));
-                    //TODO: Check this is not used. Should be added in authentication callback
-                    //claims.Add(new Claim(ClaimTypes.Name, claims.First(c => c.Type == "name").Value));
                     claims.Add(new Claim("access_token", response.AccessToken));
                     claims.Add(new Claim("expires_at", (DateTime.UtcNow.ToEpochTime() + response.ExpiresIn).ToDateTimeFromEpoch().ToString()));
                 }

--- a/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/TokenValidationMethod.cs
+++ b/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/TokenValidationMethod.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.OidcMiddleware
+{
+    public enum TokenValidationMethod
+    {
+        BinarySecret = 1,
+        SigningKey = 2
+    }
+}

--- a/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/Validators/SecurityTokenValidation.cs
+++ b/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/Validators/SecurityTokenValidation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens;
 using System.Linq;
 using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
 using System.ServiceModel.Security.Tokens;
 using System.Text;
 using Newtonsoft.Json.Linq;
@@ -19,7 +20,7 @@ namespace SFA.DAS.OidcMiddleware.Validators
             _options = options;
         }
 
-        public  List<Claim> ValidateToken(string token, string nonce)
+        public List<Claim> ValidateToken(string token, string nonce)
         {
             byte[] keyBytes = Encoding.UTF8.GetBytes(_options.ClientSecret);
             Array.Resize(ref keyBytes, 64);
@@ -27,14 +28,31 @@ namespace SFA.DAS.OidcMiddleware.Validators
             var parameters = new TokenValidationParameters
             {
                 ValidAudience = _options.ClientId,
-                ValidIssuer = _options.BaseUrl + "/Login",
-                IssuerSigningToken = new BinarySecretSecurityToken(keyBytes)
+                ValidIssuer = _options.BaseUrl,
             };
+
+            if (_options.TokenValidationMethod == TokenValidationMethod.SigningKey)
+            {
+                if (_options.TokenSigningCertificateLoader == null)
+                {
+                    throw new Exception(
+                        "Options does not have TokenSigningCertificateLoader, which is required for TokenValidationMethod of SigningKey");
+                }
+                parameters.IssuerSigningKeyResolver = (token1, securityToken, keyIdentifier, validationParameters) =>
+                {
+                    var certificate = _options.TokenSigningCertificateLoader();
+                    return new X509SecurityKey(certificate);
+                };
+            }
+            else
+            {
+                parameters.IssuerSigningToken = new BinarySecretSecurityToken(keyBytes);
+            }
 
             SecurityToken jwt;
             var principal = new JwtSecurityTokenHandler().ValidateToken(token, parameters, out jwt);
             var nonceClaim = principal.FindAll("nonce").FirstOrDefault();
-            
+
             if (!string.Equals(nonceClaim.Value, nonce, StringComparison.Ordinal))
             {
                 throw new Exception("invalid nonce");


### PR DESCRIPTION
Make token validation method configurable to support signing certificate. This is to support IDS implementation.

Also makes breaking change as built in name => ClaimTypes.Name translation has been removed as it is specific to an IDP provider. This can be done in AuthenticatedCallback if needed by client