### PR TITLE
Update Commitment Patch for Employer and Provider

### DIFF
--- a/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Client/CommitmentsApi.cs
+++ b/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Client/CommitmentsApi.cs
@@ -54,18 +54,18 @@ namespace SFA.DAS.Commitments.Api.Client
             return await GetApprenticeship(url);
         }
 
-        public async Task PatchEmployerCommitment(long employerAccountId, long commitmentId, LastAction lastAction)
+        public async Task PatchEmployerCommitment(long employerAccountId, long commitmentId, CommitmentSubmission submission)
         {
             var url = $"{_configuration.BaseUrl}api/employer/{employerAccountId}/commitments/{commitmentId}";
 
-            await PatchCommitment(url, lastAction);
+            await PatchCommitment(url, submission);
         }
 
-        public async Task PatchProviderCommitment(long providerId, long commitmentId, LastAction lastAction)
+        public async Task PatchProviderCommitment(long providerId, long commitmentId, CommitmentSubmission submission)
         {
             var url = $"{_configuration.BaseUrl}api/provider/{providerId}/commitments/{commitmentId}";
 
-            await PatchCommitment(url, lastAction);
+            await PatchCommitment(url, submission);
         }
 
         public async Task CreateEmployerApprenticeship(long employerAccountId, long commitmentId, Apprenticeship apprenticeship)
@@ -174,9 +174,9 @@ namespace SFA.DAS.Commitments.Api.Client
             return JsonConvert.DeserializeObject<Commitment>(content);
         }
 
-        private async Task PatchCommitment(string url, LastAction lastAction)
+        private async Task PatchCommitment(string url, CommitmentSubmission submision)
         {
-            var data = JsonConvert.SerializeObject(lastAction);
+            var data = JsonConvert.SerializeObject(submision);
             await PatchAsync(url, data);
         }
 

--- a/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Client/ICommitmentsApi.cs
+++ b/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Client/ICommitmentsApi.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.Commitments.Api.Client
         Task<List<CommitmentListItem>> GetEmployerCommitments(long employerAccountId);
         Task<Commitment> GetEmployerCommitment(long employerAccountId, long commitmentId);
         Task<Commitment> CreateEmployerCommitment(long employerAccountId, Commitment commitment);
-        Task PatchEmployerCommitment(long employerAccountId, long commitmentId, LastAction lastAction);
+        Task PatchEmployerCommitment(long employerAccountId, long commitmentId, CommitmentSubmission submission);
         Task<List<Apprenticeship>> GetEmployerApprenticeships(long employerAccountId);
         Task<Apprenticeship> GetEmployerApprenticeship(long employerAccountId, long apprenticeshipId);
         Task UpdateEmployerApprenticeship(long employerAccountId, long commitmentId, long apprenticeshipId, Apprenticeship apprenticeship);
@@ -25,7 +25,7 @@ namespace SFA.DAS.Commitments.Api.Client
         Task<Apprenticeship> GetProviderApprenticeship(long providerId, long apprenticeshipId);
         Task CreateProviderApprenticeship(long providerId, long commitmentId, Apprenticeship apprenticeship);
         Task UpdateProviderApprenticeship(long providerId, long commitmentId, long apprenticeshipId, Apprenticeship apprenticeship);
-        Task PatchProviderCommitment(long providerId, long commitmentId, LastAction lastAction);
+        Task PatchProviderCommitment(long providerId, long commitmentId, CommitmentSubmission submission);
         Task BulkUploadApprenticeships(long providerId, long commitmentId, IList<Apprenticeship> apprenticeships);
         Task DeleteProviderApprenticeship(long providerId, long apprenticeshipId);
         Task DeleteProviderCommitment(long providerId, long commitmentId);

--- a/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Types/Commitment.cs
+++ b/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Types/Commitment.cs
@@ -1,13 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace SFA.DAS.Commitments.Api.Types
 {
-    public class Commitment
+    public sealed class Commitment
     {
         public Commitment()
         {
             Apprenticeships = new List<Apprenticeship>();
+            EmployerLastUpdateInfo = new LastUpdateInfo();
+            ProviderLastUpdateInfo = new LastUpdateInfo();
         }
 
         public long Id { get; set; }
@@ -23,5 +24,7 @@ namespace SFA.DAS.Commitments.Api.Types
         public AgreementStatus AgreementStatus { get; set; }
         public LastAction LastAction { get; set; }
         public bool CanBeApproved { get; set; }
+        public LastUpdateInfo EmployerLastUpdateInfo { get; set; }
+        public LastUpdateInfo ProviderLastUpdateInfo { get; set; }
     }
 }

--- a/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Types/CommitmentListItem.cs
+++ b/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Types/CommitmentListItem.cs
@@ -1,8 +1,6 @@
-﻿using System;
-
-namespace SFA.DAS.Commitments.Api.Types
+﻿namespace SFA.DAS.Commitments.Api.Types
 {
-    public class CommitmentListItem
+    public sealed class CommitmentListItem
     {
         public long Id { get; set; }
         public string Reference { get; set; }
@@ -17,5 +15,7 @@ namespace SFA.DAS.Commitments.Api.Types
         public AgreementStatus AgreementStatus { get; set; }
         public LastAction LastAction { get; set; }
         public bool CanBeApproved { get; set; }
+        public LastUpdateInfo EmployerLastUpdateInfo { get; set; }
+        public LastUpdateInfo ProviderLastUpdateInfo { get; set; }
     }
 }

--- a/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Types/CommitmentSubmission.cs
+++ b/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Types/CommitmentSubmission.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.Commitments.Api.Types
+{
+    public sealed class CommitmentSubmission
+    {
+        public LastAction Action { get; set; }
+        public LastUpdateInfo LastUpdatedByInfo { get; set; }
+    }
+}

--- a/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Types/LastUpdateInfo.cs
+++ b/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Types/LastUpdateInfo.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.Commitments.Api.Types
+{
+    public sealed class LastUpdateInfo
+    {
+        public string Name { get; set; }
+        public string EmailAddress { get; set; }
+    }
+}

--- a/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Types/SFA.DAS.Commitments.Api.Types.csproj
+++ b/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.Types/SFA.DAS.Commitments.Api.Types.csproj
@@ -43,8 +43,10 @@
   <ItemGroup>
     <Compile Include="AgreementStatus.cs" />
     <Compile Include="Apprenticeship.cs" />
+    <Compile Include="CommitmentSubmission.cs" />
     <Compile Include="EditStatus.cs" />
     <Compile Include="LastAction.cs" />
+    <Compile Include="LastUpdateInfo.cs" />
     <Compile Include="PaymentStatus.cs" />
     <Compile Include="Commitment.cs" />
     <Compile Include="CommitmentListItem.cs" />


### PR DESCRIPTION
Takes the name and email of the submitter when Patching Commitment

Adds Employer and Provider properties onto Commitment with the last
updater.