### PR TITLE
removing setters from events API configuration interface

### DIFF
--- a/SFA.DAS.Events.Api/SFA.DAS.Events.Api.Client/Configuration/IEventsApiClientConfiguration.cs
+++ b/SFA.DAS.Events.Api/SFA.DAS.Events.Api.Client/Configuration/IEventsApiClientConfiguration.cs
@@ -2,7 +2,7 @@
 {
     public interface IEventsApiClientConfiguration
     {
-        string BaseUrl { get; set; }
-        string ClientToken { get; set; }
+        string BaseUrl { get; }
+        string ClientToken { get; }
     }
 }


### PR DESCRIPTION
When I create a concrete class for IEventsApiClientConfiguration I can't use an expression-bodied property because it requires setters.