### PR TITLE
Log the application version instead of logger version

### DIFF
--- a/Logging/SFA.DAS.NLog.Logger/NLogLogger.cs
+++ b/Logging/SFA.DAS.NLog.Logger/NLogLogger.cs
@@ -127,7 +127,7 @@ namespace SFA.DAS.NLog.Logger
         private string GetVersion(Type callingType)
         {
             var assembly = callingType.Assembly;
-            FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+            var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
             return fileVersionInfo.ProductVersion;
         }
 

--- a/Logging/SFA.DAS.NLog.Logger/NLogLogger.cs
+++ b/Logging/SFA.DAS.NLog.Logger/NLogLogger.cs
@@ -12,23 +12,11 @@ namespace SFA.DAS.NLog.Logger
         private readonly string _loggerType;
         private readonly string _version;
 
-        public NLogLogger()
-        {
-            _loggerType = "DefaultLogger";
-            _version = GetVersion();
-        }
-
-        public NLogLogger(Type loggerType)
-        {
-            _loggerType = loggerType?.ToString() ?? "DefaultLogger";
-            _version = GetVersion();
-        }
-
-        public NLogLogger(Type loggerType, IRequestContext context)
+        public NLogLogger(Type loggerType = null, IRequestContext context = null)
         {
             _loggerType = loggerType?.ToString() ?? "DefaultLogger";
             _context = context;
-            _version = GetVersion();
+            _version = GetVersion(loggerType);
         }
 
         public void Trace(string message)
@@ -136,9 +124,9 @@ namespace SFA.DAS.NLog.Logger
             SendLog(message, LogLevel.Fatal, properties, ex);
         }
 
-        private string GetVersion()
+        private string GetVersion(Type callingType)
         {
-            Assembly assembly = Assembly.GetExecutingAssembly();
+            var assembly = callingType.Assembly;
             FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
             return fileVersionInfo.ProductVersion;
         }

--- a/Logging/SFA.DAS.NLog.Logger/NLogLogger.cs
+++ b/Logging/SFA.DAS.NLog.Logger/NLogLogger.cs
@@ -16,7 +16,7 @@ namespace SFA.DAS.NLog.Logger
         {
             _loggerType = loggerType?.ToString() ?? "DefaultLogger";
             _context = context;
-            _version = GetVersion(loggerType);
+            _version = GetVersion(loggerType ?? GetType());
         }
 
         public void Trace(string message)


### PR DESCRIPTION
This now takes the version from the passed type instead of using the version on the logger nuget package