### PR TITLE
Override the app_Name on the redis target

### DIFF
--- a/Logging/SFA.DAS.NLog.Logger/NLogLogger.cs
+++ b/Logging/SFA.DAS.NLog.Logger/NLogLogger.cs
@@ -31,6 +31,8 @@ namespace SFA.DAS.NLog.Logger
             _version = GetVersion();
         }
 
+        public string ApplicationName { get; set; }
+
         public void Trace(string message)
         {
             SendLog(message, LogLevel.Trace);
@@ -176,6 +178,10 @@ namespace SFA.DAS.NLog.Logger
             propertiesLocal.Add("LoggerType", _loggerType);
             propertiesLocal.Add("Version", _version);
             propertiesLocal.Add("LogTimestamp", DateTime.UtcNow.ToString("o"));
+            if (!string.IsNullOrEmpty(ApplicationName))
+            {
+                propertiesLocal.Add("app_Name", ApplicationName);
+            }
 
             var logEvent = new LogEventInfo(level, _loggerType, message.ToString());
             logEvent.Exception = exception;

--- a/Logging/SFA.DAS.NLog.Targets.Redis/RedisTarget.cs
+++ b/Logging/SFA.DAS.NLog.Targets.Redis/RedisTarget.cs
@@ -10,6 +10,8 @@
     [Target("Redis")]
     public sealed class RedisTarget : TargetWithLayout
     {
+        private const string AppNameKey = "app_Name";
+
         private RedisConnectionManager _redisConnectionManager;
         private string _key;
 
@@ -79,9 +81,9 @@
             properties.Add("message", message);
             properties.Add("level", logEvent.Level.Name);
             properties.Add("@timestamp", logEvent.TimeStamp);
-            if (!properties.ContainsKey("app_Name"))
+            if (!properties.ContainsKey(AppNameKey))
             {
-                properties.Add("app_Name", AppName);
+                properties.Add(AppNameKey, AppName);
             }
 
             if (!properties.ContainsKey("Environment") && !string.IsNullOrEmpty(EnvironmentKey))

--- a/Logging/SFA.DAS.NLog.Targets.Redis/RedisTarget.cs
+++ b/Logging/SFA.DAS.NLog.Targets.Redis/RedisTarget.cs
@@ -78,8 +78,11 @@
             
             properties.Add("message", message);
             properties.Add("level", logEvent.Level.Name);
-            properties.Add("app_Name", AppName);
             properties.Add("@timestamp", logEvent.TimeStamp);
+            if (!properties.ContainsKey("app_Name"))
+            {
+                properties.Add("app_Name", AppName);
+            }
 
             if (!properties.ContainsKey("Environment") && !string.IsNullOrEmpty(EnvironmentKey))
             {


### PR DESCRIPTION
In one of our worker roles we use host multiple indexers and we pragmatically set the application name. So in order to adopt this package I've added a way to override the app_Name in the redis target.