### PR TITLE
allow properties in the constructor of the Logger

### DIFF
--- a/Logging/SFA.DAS.NLog.Logger/NLogLogger.cs
+++ b/Logging/SFA.DAS.NLog.Logger/NLogLogger.cs
@@ -10,16 +10,17 @@ namespace SFA.DAS.NLog.Logger
     {
         private readonly IRequestContext _context;
         private readonly string _loggerType;
-        private readonly string _version;
 
         public NLogLogger(Type loggerType = null, IRequestContext context = null)
         {
             _loggerType = loggerType?.ToString() ?? "DefaultLogger";
             _context = context;
-            _version = GetVersion(loggerType ?? GetType());
+            Version = GetVersion(loggerType ?? GetType());
         }
 
         public string ApplicationName { get; set; }
+
+        public string Version { get; set; }
 
         public void Trace(string message)
         {
@@ -164,7 +165,7 @@ namespace SFA.DAS.NLog.Logger
                 propertiesLocal.Add("RequestCtx", _context);
 
             propertiesLocal.Add("LoggerType", _loggerType);
-            propertiesLocal.Add("Version", _version);
+            propertiesLocal.Add("Version", Version);
             propertiesLocal.Add("LogTimestamp", DateTime.UtcNow.ToString("o"));
             if (!string.IsNullOrEmpty(ApplicationName))
             {

--- a/Logging/SFA.DAS.NLog.Logger/NLogLogger.cs
+++ b/Logging/SFA.DAS.NLog.Logger/NLogLogger.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.NLog.Logger
         {
             _loggerType = loggerType?.ToString() ?? "DefaultLogger";
             _context = context;
-            Version = GetVersion(loggerType ?? GetType());
+            Version = loggerType == null ? null : GetVersion(loggerType);
         }
 
         public string ApplicationName { get; set; }


### PR DESCRIPTION
A couple changes to fix #82
- adds a dictionary to the constructor of the NLogLogger to allow for properties like the version to be overridden
- removes the default version number being the NLogLogger assembly version