### PR TITLE
Aml 1239 multiple message type support

### DIFF
--- a/Messaging/PublishReceiveSample/PublishReceiveSample.csproj
+++ b/Messaging/PublishReceiveSample/PublishReceiveSample.csproj
@@ -78,7 +78,7 @@
       <Name>SFA.DAS.Messaging.AzureServiceBus</Name>
     </ProjectReference>
     <ProjectReference Include="..\SFA.DAS.Messaging.AzureStorageQueue\SFA.DAS.Messaging.AzureStorageQueue.csproj">
-      <Project>{95699E7A-2024-43FD-A27E-20EE3E15E515}</Project>
+      <Project>{95699e7a-2024-43fd-a27e-20ee3e15e515}</Project>
       <Name>SFA.DAS.Messaging.AzureStorageQueue</Name>
     </ProjectReference>
     <ProjectReference Include="..\SFA.DAS.Messaging.Syndication.SqlServer\SFA.DAS.Messaging.Syndication.SqlServer.csproj">

--- a/Messaging/SFA.DAS.Messaging.AzureServiceBus/AzureServiceBusMessageService.cs
+++ b/Messaging/SFA.DAS.Messaging.AzureServiceBus/AzureServiceBusMessageService.cs
@@ -11,7 +11,8 @@ namespace SFA.DAS.Messaging.AzureServiceBus
         private readonly string _connectionString;
         private readonly string _queueName;
 
-        public AzureServiceBusMessageService(string connectionString, string queueName)
+
+        public AzureServiceBusMessageService(string connectionString, string queueName = "")
         {
             _connectionString = connectionString;
             _queueName = queueName;
@@ -19,7 +20,7 @@ namespace SFA.DAS.Messaging.AzureServiceBus
 
         public async Task PublishAsync(object message)
         {
-            var client = QueueClient.CreateFromConnectionString(_connectionString, _queueName);
+            var client = QueueClient.CreateFromConnectionString(_connectionString, !string.IsNullOrEmpty(_queueName) ? _queueName : message.GetType().Name);
             var brokeredMessage = new BrokeredMessage(message)
             {
                 MessageId = Guid.NewGuid().ToString()
@@ -30,7 +31,7 @@ namespace SFA.DAS.Messaging.AzureServiceBus
 
         public async Task<Message<T>> ReceiveAsAsync<T>() where T : new()
         {
-            var client = QueueClient.CreateFromConnectionString(_connectionString, _queueName);
+            var client = QueueClient.CreateFromConnectionString(_connectionString, !string.IsNullOrEmpty(_queueName) ? _queueName : typeof(T).Name);
             var brokeredMessage = await client.ReceiveAsync();
             if (brokeredMessage == null)
             {
@@ -41,9 +42,10 @@ namespace SFA.DAS.Messaging.AzureServiceBus
         }
         public async Task<IEnumerable<Message<T>>> ReceiveBatchAsAsync<T>(int batchSize) where T : new()
         {
-            var client = QueueClient.CreateFromConnectionString(_connectionString, _queueName);
+            var client = QueueClient.CreateFromConnectionString(_connectionString, !string.IsNullOrEmpty(_queueName) ? _queueName : typeof(T).Name);
             var batch = await client.ReceiveBatchAsync(batchSize);
             return batch.Select(m => new AzureServiceBusMessage<T>(m));
         }
+        
     }
 }


### PR DESCRIPTION
This change allows you to send different messages to different queues using the same connection set in the Publisher.

If the queuename is set it will fall back to that