### PR TITLE
Catching all exception when de-serializing and dead lettering message

### DIFF
--- a/Messaging/SFA.DAS.Messaging.AzureServiceBus/TopicMessageSubscriber.cs
+++ b/Messaging/SFA.DAS.Messaging.AzureServiceBus/TopicMessageSubscriber.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Microsoft.ServiceBus.Messaging;
@@ -128,19 +129,12 @@ namespace SFA.DAS.Messaging.AzureServiceBus
             {
                 return new AzureServiceBusMessage<T>(brokeredMessage);
             }
-            catch (SerializationException ex)
+            catch (Exception ex)
             {
                  _logger.Error(ex, "Could not deserialise message from azure queue. Message will be dead lettered.");
 
                 //Dead letter the message as it can never be processed.
-                await brokeredMessage.DeadLetterAsync("Message serialisation failed", ex.Message);
-            }
-            catch (InvalidDataContractException ex)
-            {
-                _logger.Error(ex, "Could not deserialise message from azure queue due to invalid data type. Message will be dead lettered.");
-
-                //Dead letter the message as it can never be processed.
-                await brokeredMessage.DeadLetterAsync("Message type was not the same as deserialisation type", ex.Message);
+                await brokeredMessage.DeadLetterAsync("Message deserialisation failed", ex.Message);
             }
 
             return null;


### PR DESCRIPTION
- We have tried to catch de-serialisation exceptions when converting the brokered message to a typed one but the exceptions seem to still get thrown as fatal later on. Given we know that this code does only one thing at the moment we have created a catch all to dead letter messages that fail to be converted as this can this be sorted later on. This code is a quick fix and will be handled better later on.