### PR TITLE
Api Substitute using HttpMessagehandlers

### DIFF
--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/ApiSubstituteTests.cs
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/ApiSubstituteTests.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.Owin.Hosting;
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SFA.DAS.ApiSubstitute.WebAPI.OwinSelfHost;
+using SFA.DAS.ApiSubstitute.WebAPI.MessageHandlers;
+using System.Net.Http;
+using Newtonsoft.Json;
+using System.Net;
+
+namespace SFA.DAS.ApiSubstitute.UnitTests
+{
+    [TestClass]
+    public class ApiSubstituteTests : IDisposable
+    {
+        private IDisposable _webApi;
+        string baseAddress = "http://localhost:9000";
+
+        ApiMessageHandlers _apiMessageHandlers;
+        TestAccount expectedresponce;
+        string route;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _apiMessageHandlers = new ApiMessageHandlers();
+            _webApi = WebApp.Start(baseAddress, appBuilder => new WebApiStartUp().Configuration(appBuilder, _apiMessageHandlers));
+            expectedresponce = new TestAccount(1);
+            route = baseAddress + "/account";
+        }
+
+        [TestMethod]
+        public async Task CanHostWebApi()
+        {
+            
+            _apiMessageHandlers.SetupGet(route, expectedresponce);
+            using (HttpClient client = new HttpClient())
+            {
+                var jsonresponse = await client.GetAsync(route);
+                jsonresponse.EnsureSuccessStatusCode();
+            }
+        }
+
+        [TestMethod]
+        public async Task CanUseApiMessageHandlersSetUpGet()
+        {
+            _apiMessageHandlers.SetupGet(route, expectedresponce);
+            using (HttpClient client = new HttpClient())
+            {
+                var jsonresponse = await client.GetAsync(route);
+                var response = JsonConvert.DeserializeObject<TestAccount>(jsonresponse.Content.ReadAsStringAsync().Result);
+                Assert.AreEqual(1, response.Accountid);
+            }
+        }
+
+        [TestMethod]
+        public async Task CanUseApiMessageHandlersSetUpPut()
+        {
+            _apiMessageHandlers.SetupGet(route, expectedresponce);
+            _apiMessageHandlers.SetupPut(route);
+            using (HttpClient client = new HttpClient())
+            {
+                var jsonresponse = await client.GetAsync(route);
+                Assert.AreEqual(HttpStatusCode.NotFound, jsonresponse.StatusCode);
+            }
+        }
+
+
+        [TestMethod]
+        public async Task CanUseApiMessageHandlersClearSetup()
+        {
+            _apiMessageHandlers.SetupGet(route, expectedresponce);
+            _apiMessageHandlers.ClearSetup();
+            using (HttpClient client = new HttpClient())
+            {
+                var jsonresponse = await client.GetAsync(route);
+                Assert.AreEqual(HttpStatusCode.NotFound, jsonresponse.StatusCode);
+            }
+        }
+
+
+        [TestMethod]
+        public async Task CanUseApiMessageHandlersSetUpGetWithResponceCode()
+        {
+            _apiMessageHandlers.SetupGet<object>(route, HttpStatusCode.BadRequest, null);
+            using (HttpClient client = new HttpClient())
+            {
+                var jsonresponse = await client.GetAsync(route);
+                Assert.AreEqual(HttpStatusCode.BadRequest, jsonresponse.StatusCode);
+            }
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Dispose();
+        }
+
+        public void Dispose()
+        {
+            _webApi.Dispose();
+        }
+    }
+}

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/Properties/AssemblyInfo.cs
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SFA.DAS.ApiSubstitute.UnitTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SFA.DAS.ApiSubstitute.UnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("27b297f9-a252-4a70-b3d1-b3e64d76ee8f")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/SFA.DAS.ApiSubstitute.UnitTests.csproj
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/SFA.DAS.ApiSubstitute.UnitTests.csproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{27B297F9-A252-4A70-B3D1-B3E64D76EE8F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SFA.DAS.ApiSubstitute.UnitTests</RootNamespace>
+    <AssemblyName>SFA.DAS.ApiSubstitute.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Owin, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.2.0.2\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.2.0.2\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.2.0.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Owin, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ApiSubstituteTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestAccount.cs" />
+    <Compile Include="WebApiSubstituteTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.ApiSubstitute.WebAPI\SFA.DAS.ApiSubstitute.WebAPI.csproj">
+      <Project>{AA6A9A50-6EB2-4BBF-98FB-625AB83D5BB8}</Project>
+      <Name>SFA.DAS.ApiSubstitute.WebAPI</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/TestAccount.cs
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/TestAccount.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApiSubstitute.UnitTests
+{
+    public class TestAccount
+    {
+        public int Accountid { get; protected set; }
+        public TestAccount(int accountid)
+        {
+            Accountid = accountid;
+        }
+    }
+}

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/WebApiSubstituteTests.cs
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/WebApiSubstituteTests.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using SFA.DAS.ApiSubstitute.WebAPI;
+using SFA.DAS.ApiSubstitute.WebAPI.MessageHandlers;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApiSubstitute.UnitTests
+{
+    [TestClass]
+    public class WebApiSubstituteTests
+    {
+
+        [TestMethod]
+        public async Task CanUseWebApiSubstitute()
+        {
+            const string eventsApibaseAddress = "http://localhost:9000";
+            var expected = new TestAccount(1);
+            string route = eventsApibaseAddress + "/events";
+
+            ApiMessageHandlers eventsapiMessageHandlers = new ApiMessageHandlers();
+            eventsapiMessageHandlers.SetupGet(route, expected);
+
+            using (WebApiSubstitute webApiSubstitute = new WebApiSubstitute(eventsApibaseAddress, eventsapiMessageHandlers))
+            {
+                using (HttpClient client = new HttpClient())
+                {
+                    var jsonresponse = await client.GetAsync(route);
+                    var response = JsonConvert.DeserializeObject<TestAccount>(jsonresponse.Content.ReadAsStringAsync().Result);
+                    Assert.AreEqual(1, response.Accountid);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task CanUseMultipleWebApiSubstitute()
+        {
+            const string eventsApibaseAddress = "http://localhost:9000";
+            var expectedevents = new TestAccount(1);
+            string eventsroute = eventsApibaseAddress + "/events";
+            ApiMessageHandlers eventsapiMessageHandlers = new ApiMessageHandlers();
+            eventsapiMessageHandlers.SetupGet(eventsroute, expectedevents);
+            WebApiSubstitute eventswebApiSubstitute = new WebApiSubstitute(eventsApibaseAddress, eventsapiMessageHandlers);
+
+            const string accountsApibaseAddress = "http://localhost:9001";
+            var expectedaccounts = new TestAccount(11);
+            string accountsroute = accountsApibaseAddress + "/accounts";
+            ApiMessageHandlers accountsapiMessageHandlers = new ApiMessageHandlers();
+            accountsapiMessageHandlers.SetupGet(accountsroute, expectedaccounts);
+            WebApiSubstitute accountswebApiSubstitute = new WebApiSubstitute(accountsApibaseAddress, accountsapiMessageHandlers);
+
+            using (HttpClient client = new HttpClient())
+            {
+                var jsonresponse = await client.GetAsync(eventsroute);
+                var response = JsonConvert.DeserializeObject<TestAccount>(jsonresponse.Content.ReadAsStringAsync().Result);
+                Assert.AreEqual(1, response.Accountid);
+            }
+            using (HttpClient client = new HttpClient())
+            {
+                var jsonresponse = await client.GetAsync(accountsroute);
+                var response = JsonConvert.DeserializeObject<TestAccount>(jsonresponse.Content.ReadAsStringAsync().Result);
+                Assert.AreEqual(11, response.Accountid);
+            }
+            eventswebApiSubstitute.Dispose();
+            accountswebApiSubstitute.Dispose();
+        }
+    }
+}

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/packages.config
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/packages.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.Owin" version="2.0.2" targetFramework="net462" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="2.0.2" targetFramework="net462" />
+  <package id="Microsoft.Owin.Hosting" version="2.0.2" targetFramework="net462" />
+  <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net462" />
+  <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net462" />
+  <package id="Owin" version="1.0" targetFramework="net462" />
+</packages>

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/App.config
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    </startup>
+</configuration>

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/App.config
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
     </startup>
 </configuration>

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/MessageHandlers/ApiMessageHandlers.cs
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/MessageHandlers/ApiMessageHandlers.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApiSubstitute.WebAPI.MessageHandlers
+{
+    public class ApiMessageHandlers : DelegateHandler
+    {
+        private class Response
+        {
+            public HttpStatusCode _statusCode;
+            public object _response;
+
+            public Response(HttpStatusCode statusCode, object response)
+            {
+                _statusCode = statusCode;
+                _response = response;
+            }
+        }
+
+        private Dictionary<string, Response> _configuredGets = new Dictionary<string, Response>();
+        
+        public void SetupGet<T>(string endPoint, T response)
+        {
+            SetupGet<T>(endPoint, HttpStatusCode.OK, response);
+        }
+
+        public void SetupGet<T>(string endPoint, HttpStatusCode httpStatusCode, T response)
+        {
+            _configuredGets.Add(GetEndPoint(endPoint), new Response(httpStatusCode, response));
+        }
+
+        public void SetupPut(string url)
+        {
+            _configuredGets.Remove(url);
+        }
+        public void ClearSetup()
+        {
+            _configuredGets.Clear();
+        }
+
+        protected override Task<HttpResponseMessage> DoSendAsync(HttpRequestMessage request)
+        {
+            var requestUri = request.RequestUri.ToString();
+            HttpResponseMessage response;
+            if (!_configuredGets.ContainsKey(requestUri))
+            {
+                response = request.CreateResponse(HttpStatusCode.NotFound);
+            }
+            else
+            {
+                response = request.CreateResponse(_configuredGets[requestUri]._statusCode, _configuredGets[requestUri]._response);
+            }
+
+            var tsc = new TaskCompletionSource<HttpResponseMessage>();
+            tsc.SetResult(response);
+            return tsc.Task;
+        }
+
+        private string GetEndPoint(string url)
+        {
+            return url.StartsWith("/")
+                ? url.TrimStart('/')
+                : url;
+        }
+    }
+}

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/MessageHandlers/DelegateHandler.cs
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/MessageHandlers/DelegateHandler.cs
@@ -1,0 +1,17 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.ApiSubstitute.WebAPI.MessageHandlers
+{
+    public abstract class DelegateHandler : DelegatingHandler
+    {
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return await DoSendAsync(request);
+        }
+
+        protected abstract Task<HttpResponseMessage> DoSendAsync(HttpRequestMessage request);
+    }
+}

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/OwinSelfHost/WebApiStartUp.cs
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/OwinSelfHost/WebApiStartUp.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.ApiSubstitute.WebAPI.OwinSelfHost
         {
             HttpConfiguration config = new HttpConfiguration();
 
-            //Add message Handlers o the Http Config
+            //Add message Handlers to the Http Config
             config.MessageHandlers.Add(messageHandlers);
 
             //Request the App Builder to use the config

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/OwinSelfHost/WebApiStartUp.cs
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/OwinSelfHost/WebApiStartUp.cs
@@ -1,0 +1,22 @@
+﻿using Owin;
+using System.Web.Http;
+using SFA.DAS.ApiSubstitute.WebAPI.MessageHandlers;
+
+namespace SFA.DAS.ApiSubstitute.WebAPI.OwinSelfHost
+{
+    public class WebApiStartUp
+    {
+        // This code configures Web API to use the Delegate message handlers. 
+        // The WebApiStartUp class is specified as a type parameter in the WebApp.Start method.
+        public void Configuration(IAppBuilder appBuilder, DelegateHandler messageHandlers)
+        {
+            HttpConfiguration config = new HttpConfiguration();
+
+            //Add message Handlers o the Http Config
+            config.MessageHandlers.Add(messageHandlers);
+
+            //Request the App Builder to use the config
+            appBuilder.UseWebApi(config);
+        }
+    }
+}

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/Properties/AssemblyInfo.cs
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SFA.DAS.ApiSubstitute.WebAPI")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SFA.DAS.ApiSubstitute.WebAPI")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("aa6a9a50-6eb2-4bbf-98fb-625ab83d5bb8")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/SFA.DAS.ApiSubstitute.WebAPI.csproj
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/SFA.DAS.ApiSubstitute.WebAPI.csproj
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AA6A9A50-6EB2-4BBF-98FB-625AB83D5BB8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>SFA.DAS.ApiSubstitute.WebAPI</RootNamespace>
+    <AssemblyName>SFA.DAS.ApiSubstitute.WebAPI</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Owin, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.2.0.2\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.2.0.2\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.2.0.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Owin, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MessageHandlers\DelegateHandler.cs" />
+    <Compile Include="MessageHandlers\ApiMessageHandlers.cs" />
+    <Compile Include="OwinSelfHost\WebApiStartUp.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WebApiSubstitute.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/SFA.DAS.ApiSubstitute.WebAPI.csproj
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/SFA.DAS.ApiSubstitute.WebAPI.csproj
@@ -8,9 +8,10 @@
     <OutputType>Library</OutputType>
     <RootNamespace>SFA.DAS.ApiSubstitute.WebAPI</RootNamespace>
     <AssemblyName>SFA.DAS.ApiSubstitute.WebAPI</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -79,6 +80,7 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
+    <None Include="SFA.DAS.ApiSubstitute.WebAPI.nuspec" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/SFA.DAS.ApiSubstitute.WebAPI.nuspec
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/SFA.DAS.ApiSubstitute.WebAPI.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>SFA.DAS.ApiSubstitute.WebAPI</id>
+    <version>1.0.0</version>
+    <title>Api Substitute</title>
+    <authors>micheal young, arvinth seran</authors>
+    <owners>sfanuget</owners>
+    <licenseUrl>https://github.com/SkillsFundingAgency/das-shared-packages/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/SkillsFundingAgency/das-shared-packages</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Class library for substituting an API response</description>
+    <summary>Substitute any Web Api response by setting the Gets in the Http message handlers use it for your Integration / Acceptance / End to End Tests. Simply start the web App inMemory in http://localHost/ along wiht any unused port and configure your api to substitute your Rest response </summary>
+    <releaseNotes>inital release of the package.</releaseNotes>
+    <dependencies>
+      <group targetFramework=".NETFramework4.6.2">
+        <dependency id="Newtonsoft.Json" version="6.0.4"/>
+        <dependency id="Microsoft.Owin" version="2.0.2"/>
+        <dependency id="Microsoft.Owin.Hosting" version="2.0.2"/>
+        <dependency id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.3"/>
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\SFA.DAS.ApiSubstitute.WebAPI.dll" target="lib\net45\SFA.DAS.ApiSubstitute.WebAPI.dll" />
+  </files>
+</package>

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/SFA.DAS.ApiSubstitute.WebAPI.nuspec
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/SFA.DAS.ApiSubstitute.WebAPI.nuspec
@@ -13,7 +13,7 @@
     <summary>Substitute any Web Api response by setting the Gets in the Http message handlers use it for your Integration / Acceptance / End to End Tests. Simply start the web App inMemory in http://localHost/ along wiht any unused port and configure your api to substitute your Rest response </summary>
     <releaseNotes>inital release of the package.</releaseNotes>
     <dependencies>
-      <group targetFramework=".NETFramework4.6.2">
+      <group targetFramework=".NETFramework4.5">
         <dependency id="Newtonsoft.Json" version="6.0.4"/>
         <dependency id="Microsoft.Owin" version="2.0.2"/>
         <dependency id="Microsoft.Owin.Hosting" version="2.0.2"/>

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/WebApiSubstitute.cs
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/WebApiSubstitute.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Owin.Hosting;
+using SFA.DAS.ApiSubstitute.WebAPI.MessageHandlers;
+using SFA.DAS.ApiSubstitute.WebAPI.OwinSelfHost;
+using System;
+using System.Collections.Generic;
+
+namespace SFA.DAS.ApiSubstitute.WebAPI
+{
+    public class WebApiSubstitute : IDisposable
+    {
+        private string _baseAddress;
+        private DelegateHandler _apiMessageHandler;
+        private IDisposable _webApi;
+
+        public WebApiSubstitute(string baseAddress, DelegateHandler apiMessageHandler)
+        {
+            _baseAddress = GetBaseUrl(baseAddress);
+            _apiMessageHandler = apiMessageHandler;
+            StartWebApiSubstitute();
+        }
+
+        public void StartWebApiSubstitute()
+        {
+            _webApi = WebApp.Start(_baseAddress, appBuilder => new WebApiStartUp().Configuration(appBuilder, _apiMessageHandler));
+        }
+
+        public void Dispose()
+        {
+            _webApi.Dispose();
+        }
+
+        private string GetBaseUrl(string baseAddress)
+        {
+            return baseAddress.EndsWith("/")
+                ? baseAddress
+                : baseAddress + "/";
+        }
+    }
+}

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/packages.config
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.WebAPI/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.3" targetFramework="net462" />
+  <package id="Microsoft.Owin" version="2.0.2" targetFramework="net462" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="2.0.2" targetFramework="net462" />
+  <package id="Microsoft.Owin.Hosting" version="2.0.2" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net462" />
+  <package id="Owin" version="1.0" targetFramework="net462" />
+</packages>

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.sln
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.16
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.ApiSubstitute.WebAPI", "SFA.DAS.ApiSubstitute.WebAPI\SFA.DAS.ApiSubstitute.WebAPI.csproj", "{AA6A9A50-6EB2-4BBF-98FB-625AB83D5BB8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{CB672405-28B3-46C5-A002-B0E1ADD90BC1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.ApiSubstitute.UnitTests", "SFA.DAS.ApiSubstitute.UnitTests\SFA.DAS.ApiSubstitute.UnitTests.csproj", "{27B297F9-A252-4A70-B3D1-B3E64D76EE8F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AA6A9A50-6EB2-4BBF-98FB-625AB83D5BB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA6A9A50-6EB2-4BBF-98FB-625AB83D5BB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA6A9A50-6EB2-4BBF-98FB-625AB83D5BB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA6A9A50-6EB2-4BBF-98FB-625AB83D5BB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27B297F9-A252-4A70-B3D1-B3E64D76EE8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27B297F9-A252-4A70-B3D1-B3E64D76EE8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27B297F9-A252-4A70-B3D1-B3E64D76EE8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27B297F9-A252-4A70-B3D1-B3E64D76EE8F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{27B297F9-A252-4A70-B3D1-B3E64D76EE8F} = {CB672405-28B3-46C5-A002-B0E1ADD90BC1}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {11EB3DF7-2693-46DF-AF8E-D9A8AF387DCF}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Substitute any Api response by setting the Gets in the Http message handlers.