### PR TITLE
Replace throw exception with just null authentication ticket

### DIFF
--- a/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/CodeFlowAuthenticationHandler.cs
+++ b/SFA.DAS.OidcMiddleware/SFA.DAS.OidcMiddleware/CodeFlowAuthenticationHandler.cs
@@ -2,6 +2,7 @@
 using System.Security.Claims;
 using System.Threading.Tasks;
 using IdentityModel;
+using Microsoft.Owin.Logging;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Infrastructure;
 using SFA.DAS.OidcMiddleware.Builders;
@@ -19,7 +20,12 @@ namespace SFA.DAS.OidcMiddleware
         private readonly ITokenValidator _tokenValidator;
         private readonly IUserInfoClient _userInfoClient;
 
-        public CodeFlowAuthenticationHandler(IAuthorizeUrlBuilder authorizeUrlBuilder, INonceCache nonceCache, ITokenClient tokenClient, ITokenValidator tokenValidator, IUserInfoClient userInfoClient)
+        public CodeFlowAuthenticationHandler(
+            IAuthorizeUrlBuilder authorizeUrlBuilder, 
+            INonceCache nonceCache, 
+            ITokenClient tokenClient, 
+            ITokenValidator tokenValidator, 
+            IUserInfoClient userInfoClient)
         {
             _authorizeUrlBuilder = authorizeUrlBuilder;
             _nonceCache = nonceCache;
@@ -42,14 +48,14 @@ namespace SFA.DAS.OidcMiddleware
 
             if (properties == null)
             {
-                throw new Exception("The original state was not found.");
+                return null;
             }
 
             var nonce = await _nonceCache.GetNonceAsync(Context.Authentication);
 
             if (nonce == null)
             {
-                throw new Exception("The original nonce was not found.");
+                return null;
             }
 
             var tokenResponse = await _tokenClient.RequestAuthorizationCodeAsync(Options.TokenEndpoint, Options.ClientId, Options.ClientSecret, code, Request.Uri);


### PR DESCRIPTION
Replace the throw exception in CodeFlowAuthenticationHandler.AuthenticateCoreAsync with just returning null. There seems to be some disagreement over whether it should return null or an access token with null properties - the documentation is not clear so took steer from https://brockallen.com/2013/08/07/owin-authentication-middleware-architecture/