### PR TITLE
Downgrade moq as we have had build issue with latest release

### DIFF
--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/SFA.DAS.ApiSubstitute.UnitTests.csproj
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/SFA.DAS.ApiSubstitute.UnitTests.csproj
@@ -50,8 +50,8 @@
     <Reference Include="Microsoft.Owin.Hosting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.Hosting.4.0.0\lib\net451\Microsoft.Owin.Hosting.dll</HintPath>
     </Reference>
-    <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.8.2\lib\net45\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.7.145.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.7.145\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -80,9 +80,6 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.4.0\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>

--- a/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/packages.config
+++ b/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute/SFA.DAS.ApiSubstitute.UnitTests/packages.config
@@ -8,13 +8,12 @@
   <package id="Microsoft.Owin" version="4.0.0" targetFramework="net462" />
   <package id="Microsoft.Owin.Host.HttpListener" version="4.0.0" targetFramework="net462" />
   <package id="Microsoft.Owin.Hosting" version="4.0.0" targetFramework="net462" />
-  <package id="Moq" version="4.8.2" targetFramework="net462" />
+  <package id="Moq" version="4.7.145" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net462" />
   <package id="NLog" version="4.4.13" targetFramework="net462" />
   <package id="NUnit" version="3.10.1" targetFramework="net462" />
   <package id="Owin" version="1.0" targetFramework="net462" />
   <package id="SFA.DAS.NLog.Logger" version="1.0.0.56651" targetFramework="net462" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.57315" targetFramework="net462" />
-  <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net462" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
- We have had issues with the build server not liking the standard version of the Task extensions nuget that latest version of Moq depends on. Given the tests don't need the latest version i've downgraded the version to see if that solves the issue in the short term.