### PR TITLE
ER-378 - Recruit Vacancy Client

### DIFF
--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/Properties/AssemblyInfo.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DAS.Recruit.Vacancies.Client.UnitTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DAS.Recruit.Vacancies.Client.UnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3adb4302-6f54-4965-9ab3-d6319a076002")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/SFA.DAS.Recruit.Vacancies.Client.UnitTests.csproj
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/SFA.DAS.Recruit.Vacancies.Client.UnitTests.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3ADB4302-6F54-4965-9AB3-D6319A076002}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SFA.DAS.Recruit.Vacancies.Client.UnitTests</RootNamespace>
+    <AssemblyName>SFA.DAS.Recruit.Vacancies.Client.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VacancyVersionHelperTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.Recruit.Vacancies.Client\SFA.DAS.Recruit.Vacancies.Client.csproj">
+      <Project>{874e7a53-2dbf-442a-af74-20190a9901f3}</Project>
+      <Name>DAS.Recruit.Vacancies.Client</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+  </Target>
+</Project>

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/VacancyVersionHelperTests.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/VacancyVersionHelperTests.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+
+namespace SFA.DAS.Recruit.Vacancies.Client.UnitTests
+{
+    [TestFixture]
+    public class VacancyVersionHelperTests
+    {
+        [Test]
+        public void IsRecruitVacancy_ShouldReturnTrueForRecruitVacancies()
+        {
+            long vacancyReference = 1000000000;
+
+            Assert.IsTrue(VacancyVersionHelper.IsRecruitVacancy(vacancyReference));
+            Assert.IsFalse(VacancyVersionHelper.IsRaaVacancy(vacancyReference));
+        }
+
+        [Test]
+        public void IsRecruitVacancy_ShouldReturnFalseForRecruitVacancies()
+        {
+            long vacancyReference = 100000000;
+
+            Assert.IsFalse(VacancyVersionHelper.IsRecruitVacancy(vacancyReference));
+            Assert.IsTrue(VacancyVersionHelper.IsRaaVacancy(vacancyReference));
+        }
+    }
+}

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/packages.config
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.10.1" targetFramework="net451" />
+</packages>

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.sln
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2036
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.Recruit.Vacancies.Client", "SFA.DAS.Recruit.Vacancies.Client\SFA.DAS.Recruit.Vacancies.Client.csproj", "{874E7A53-2DBF-442A-AF74-20190A9901F3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.Recruit.Vacancies.Client.UnitTests", "SFA.DAS.Recruit.Vacancies.Client.UnitTests\SFA.DAS.Recruit.Vacancies.Client.UnitTests.csproj", "{3ADB4302-6F54-4965-9AB3-D6319A076002}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{874E7A53-2DBF-442A-AF74-20190A9901F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{874E7A53-2DBF-442A-AF74-20190A9901F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{874E7A53-2DBF-442A-AF74-20190A9901F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{874E7A53-2DBF-442A-AF74-20190A9901F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3ADB4302-6F54-4965-9AB3-D6319A076002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3ADB4302-6F54-4965-9AB3-D6319A076002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3ADB4302-6F54-4965-9AB3-D6319A076002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3ADB4302-6F54-4965-9AB3-D6319A076002}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D5E9971D-1CF4-4003-989F-D8D95BBC5D01}
+	EndGlobalSection
+EndGlobal

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Client.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Client.cs
@@ -1,0 +1,56 @@
+﻿using System.Security.Authentication;
+using MongoDB.Bson.Serialization.Conventions;
+using MongoDB.Driver;
+using SFA.DAS.Recruit.Vacancies.Client.Entities;
+
+namespace SFA.DAS.Recruit.Vacancies.Client
+{
+    public class Client : IClient
+    {
+        private const string IdFormat = "LiveVacancy_{0}";
+
+        private readonly string _connectionString;
+        private readonly string _databaseName;
+        private readonly string _collectionName;
+
+        static Client()
+        {
+            var pack = new ConventionPack
+            {
+                new CamelCaseElementNameConvention(),
+                new EnumRepresentationConvention(MongoDB.Bson.BsonType.String),
+                new IgnoreExtraElementsConvention(true),
+                new IgnoreIfNullConvention(true)
+            };
+            ConventionRegistry.Register("recruit conventions", pack, t => true);
+        }
+        
+        public Client(string connectionString, string databaseName, string collectionName)
+        {
+            _connectionString = connectionString;
+            _databaseName = databaseName;
+            _collectionName = collectionName;
+        }
+
+        public LiveVacancy GetVacancy(long vacancyReference)
+        {
+            var id = string.Format(IdFormat, vacancyReference);
+            
+            var collection = GetCollection();
+            var result = collection.FindOneById(id);
+            return result;
+        }
+
+        private MongoCollection<LiveVacancy> GetCollection()
+        {
+            var settings = MongoClientSettings.FromUrl(new MongoUrl(_connectionString));
+            settings.SslSettings = new SslSettings { EnabledSslProtocols = SslProtocols.Tls12 };
+            
+            var client = new MongoClient(settings);
+            var database = client.GetServer().GetDatabase(_databaseName);
+            var collection = database.GetCollection<LiveVacancy>(_collectionName);
+
+            return collection;
+        }
+    }
+}

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/Address.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/Address.cs
@@ -1,0 +1,13 @@
+﻿namespace SFA.DAS.Recruit.Vacancies.Client.Entities
+{
+    public class Address
+    {
+        public string AddressLine1 { get; set; }
+        public string AddressLine2 { get; set; }
+        public string AddressLine3 { get; set; }
+        public string AddressLine4 { get; set; }
+        public string Postcode { get; set; }
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+    }
+}

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/LiveVacancy.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/LiveVacancy.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SFA.DAS.Recruit.Vacancies.Client.Entities
+{
+    public class LiveVacancy
+    {
+        public string Id { get; set; }
+        public string Type { get; set; }
+        public DateTime LastUpdated { get; set; }
+
+        public Guid VacancyId { get; set; }
+        public string ApplicationInstructions { get; set; }
+        public string ApplicationUrl { get; set; }
+        public DateTime ClosingDate { get; set; }
+        public string Description { get; set; }
+        public string EmployerContactEmail { get; set; }
+        public string EmployerContactName { get; set; }
+        public string EmployerContactPhone { get; set; }
+        public string EmployerDescription { get; set; }
+        public Address EmployerLocation { get; set; }
+        public string EmployerName { get; set; }
+        public string EmployerWebsiteUrl { get; set; }
+
+        public DateTime LiveDate { get; set; }
+        public int NumberOfPositions { get; set; }
+        public string OutcomeDescription { get; set; }
+        public string ProgrammeId { get; set; }
+        public string ProgrammeLevel { get; set; }
+        public string ProgrammeType { get; set; }
+        public IEnumerable<Qualification> Qualifications { get; set; }
+        public string ShortDescription { get; set; }
+        public IEnumerable<string> Skills { get; set; }
+        public DateTime StartDate { get; set; }
+        public string ThingsToConsider { get; set; }
+        public string Title { get; set; }
+        public string TrainingDescription { get; set; }
+        public TrainingProvider TrainingProvider { get; set; }
+        public long VacancyReference { get; set; }
+        public Wage Wage { get; set; }
+    }
+}

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/LiveVacancy.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/LiveVacancy.cs
@@ -8,7 +8,6 @@ namespace SFA.DAS.Recruit.Vacancies.Client.Entities
         public string Id { get; set; }
         public string Type { get; set; }
         public DateTime LastUpdated { get; set; }
-
         public Guid VacancyId { get; set; }
         public string ApplicationInstructions { get; set; }
         public string ApplicationUrl { get; set; }
@@ -21,7 +20,6 @@ namespace SFA.DAS.Recruit.Vacancies.Client.Entities
         public Address EmployerLocation { get; set; }
         public string EmployerName { get; set; }
         public string EmployerWebsiteUrl { get; set; }
-
         public DateTime LiveDate { get; set; }
         public int NumberOfPositions { get; set; }
         public string OutcomeDescription { get; set; }

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/Qualification.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/Qualification.cs
@@ -1,0 +1,10 @@
+﻿namespace SFA.DAS.Recruit.Vacancies.Client.Entities
+{
+    public class Qualification
+    {
+        public string QualificationType { get; set; }
+        public string Subject { get; set; }
+        public string Grade { get; set; }
+        public string Weighting { get; set; }
+    }
+}

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/TrainingProvider.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/TrainingProvider.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.Recruit.Vacancies.Client.Entities
+{
+    public class TrainingProvider
+    {
+        public long Ukprn { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/Wage.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/Wage.cs
@@ -1,0 +1,19 @@
+﻿namespace SFA.DAS.Recruit.Vacancies.Client.Entities
+{
+    public class Wage
+    {
+        public int Duration { get; set; }
+
+        public string DurationUnit { get; set; }
+
+        public string WorkingWeekDescription { get; set; }
+
+        public decimal WeeklyHours { get; set; }
+
+        public string WageType { get; set; }
+
+        public decimal? FixedWageYearlyAmount { get; set; }
+
+        public string WageAdditionalInformation { get; set; }
+    }
+}

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/IClient.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/IClient.cs
@@ -1,0 +1,9 @@
+﻿using SFA.DAS.Recruit.Vacancies.Client.Entities;
+
+namespace SFA.DAS.Recruit.Vacancies.Client
+{
+    public interface IClient
+    {
+        LiveVacancy GetVacancy(long vacancyReference);
+    }
+}

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Properties/AssemblyInfo.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DAS.Recruit.Vacancies.Client")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DAS.Recruit.Vacancies.Client")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("874e7a53-2dbf-442a-af74-20190a9901f3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.csproj
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{874E7A53-2DBF-442A-AF74-20190A9901F3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SFA.DAS.Recruit.Vacancies.Client</RootNamespace>
+    <AssemblyName>SFA.DAS.Recruit.Vacancies.Client</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="MongoDB.Bson, Version=1.10.0.62, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <HintPath>..\packages\mongocsharpdriver.1.10.0\lib\net35\MongoDB.Bson.dll</HintPath>
+    </Reference>
+    <Reference Include="MongoDB.Driver, Version=1.10.0.62, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <HintPath>..\packages\mongocsharpdriver.1.10.0\lib\net35\MongoDB.Driver.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Client.cs" />
+    <Compile Include="Entities\Address.cs" />
+    <Compile Include="Entities\LiveVacancy.cs" />
+    <Compile Include="Entities\Qualification.cs" />
+    <Compile Include="Entities\TrainingProvider.cs" />
+    <Compile Include="Entities\Wage.cs" />
+    <Compile Include="IClient.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VacancyVersionHelper.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="SFA.DAS.Recruit.Vacancies.Client.nuspec" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.nuspec
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>SFA.DAS.Recruit.Vacancies.Client</id>
-    <version>1.0.0-alpha</version>
+    <version>1.0.0</version>
     <authors>DAS</authors>
     <owners>DAS</owners>
     <licenseUrl>https://github.com/SkillsFundingAgency/das-shared-packages/blob/master/LICENSE</licenseUrl>

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.nuspec
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>SFA.DAS.Recruit.Vacancies.Client</id>
+    <version>1.0.0-alpha</version>
+    <authors>DAS</authors>
+    <owners>DAS</owners>
+    <licenseUrl>https://github.com/SkillsFundingAgency/das-shared-packages/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/SkillsFundingAgency/das-shared-packages</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Client package to retrieve vacancies from the Recruit Vacancies query store</description>
+    <releaseNotes/>
+    <dependencies>
+      <group targetFramework=".NETFramework4.5">
+        <dependency id="mongocsharpdriver" version="1.10.0" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\SFA.DAS.Recruit.Vacancies.Client.dll" target="lib\net45\SFA.DAS.Recruit.Vacancies.Client.dll" />
+  </files>
+</package>

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/VacancyVersionHelper.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/VacancyVersionHelper.cs
@@ -1,0 +1,17 @@
+﻿namespace SFA.DAS.Recruit.Vacancies.Client
+{
+    public static class VacancyVersionHelper
+    {
+        private const int V2VacancyIdLength = 10;
+
+        public static bool IsRecruitVacancy(long vacancyId)
+        {
+            return vacancyId.ToString("D").Length == V2VacancyIdLength;
+        }
+
+        public static bool IsRaaVacancy(long vacancyId)
+        {
+            return !(IsRecruitVacancy(vacancyId));
+        }
+    }
+}

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/packages.config
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="mongocsharpdriver" version="1.10.0" targetFramework="net451" />
+</packages>


### PR DESCRIPTION
.NET version is the same as FAA (4.5.1)
Mongo driver is the same as that used by FAA (1.10.0)

`Client.cs` has a single public function `GetVacancy`. This returns a vacancy as it is in the query store.

`VacancyVersionHelper.cs` is a helper class to determine what version a vacancy is by its number. 10 digits means it is a v2 vacancy.