### PR TITLE
Enhance Entity Framework Stub

### DIFF
--- a/SFA.DAS.Testing/SFA.DAS.Testing.EntityFramework/DbSetStub.cs
+++ b/SFA.DAS.Testing/SFA.DAS.Testing.EntityFramework/DbSetStub.cs
@@ -69,15 +69,5 @@ namespace SFA.DAS.Testing.EntityFramework
             _local.Add(item);
             return item;
         }
-
-        public override T Create()
-        {
-            return Activator.CreateInstance<T>();
-        }
-
-        public override TDerivedEntity Create<TDerivedEntity>()
-        {
-            return Activator.CreateInstance<TDerivedEntity>();
-        }
     }
 }

--- a/SFA.DAS.Testing/SFA.DAS.Testing.EntityFramework/DbSetStub.cs
+++ b/SFA.DAS.Testing/SFA.DAS.Testing.EntityFramework/DbSetStub.cs
@@ -52,8 +52,6 @@ namespace SFA.DAS.Testing.EntityFramework
             return GetEnumerator();
         }
 
-        #region Entity Operations
-
         public override T Add(T item)
         {
             //todo: clone on the way in?
@@ -82,7 +80,5 @@ namespace SFA.DAS.Testing.EntityFramework
         {
             return Activator.CreateInstance<TDerivedEntity>();
         }
-
-        #endregion Entity Operations
     }
 }

--- a/SFA.DAS.Testing/SFA.DAS.Testing.EntityFramework/DbSetStub.cs
+++ b/SFA.DAS.Testing/SFA.DAS.Testing.EntityFramework/DbSetStub.cs
@@ -54,7 +54,6 @@ namespace SFA.DAS.Testing.EntityFramework
 
         public override T Add(T item)
         {
-            //todo: clone on the way in?
             _local.Add(item);
             return item;
         }

--- a/SFA.DAS.Testing/SFA.DAS.Testing.EntityFramework/DbSetStub.cs
+++ b/SFA.DAS.Testing/SFA.DAS.Testing.EntityFramework/DbSetStub.cs
@@ -9,15 +9,18 @@ using System.Linq.Expressions;
 
 namespace SFA.DAS.Testing.EntityFramework
 {
+    /// <remarks>
+    /// See https://docs.microsoft.com/en-us/ef/ef6/fundamentals/testing/writing-test-doubles
+    /// </remarks>
     public class DbSetStub<T> : DbSet<T>, IDbAsyncEnumerable<T>, IQueryable<T> where T : class
     {
-        public Expression Expression => _data.Expression;
-        public Type ElementType => _data.ElementType;
-        public override ObservableCollection<T> Local => _local ?? (_local = new ObservableCollection<T>(_data));
-        public IQueryProvider Provider => new DbAsyncQueryProviderStub<T>(_data.Provider);
+        public Expression Expression => _query.Expression;
+        public Type ElementType => _query.ElementType;
+        public override ObservableCollection<T> Local => _local;
+        public IQueryProvider Provider => new DbAsyncQueryProviderStub<T>(_query.Provider);
 
-        private readonly IQueryable<T> _data;
-        private ObservableCollection<T> _local;
+        private readonly IQueryable<T> _query;
+        private readonly ObservableCollection<T> _local;
 
         public DbSetStub(params T[] data) : this(data.AsEnumerable())
         {
@@ -25,12 +28,13 @@ namespace SFA.DAS.Testing.EntityFramework
 
         public DbSetStub(IEnumerable<T> data)
         {
-            _data = data.AsQueryable();
+            _query = data.AsQueryable();
+            _local = new ObservableCollection<T>(_query);
         }
 
         public IDbAsyncEnumerator<T> GetAsyncEnumerator()
         {
-            return new DbAsyncEnumeratorStub<T>(_data.GetEnumerator());
+            return new DbAsyncEnumeratorStub<T>(_local.GetEnumerator());
         }
 
         IDbAsyncEnumerator IDbAsyncEnumerable.GetAsyncEnumerator()
@@ -40,12 +44,45 @@ namespace SFA.DAS.Testing.EntityFramework
 
         public IEnumerator<T> GetEnumerator()
         {
-            return _data.GetEnumerator();
+            return _local.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
         }
+
+        #region Entity Operations
+
+        public override T Add(T item)
+        {
+            //todo: clone on the way in?
+            _local.Add(item);
+            return item;
+        }
+
+        public override T Remove(T item)
+        {
+            _local.Remove(item);
+            return item;
+        }
+
+        public override T Attach(T item)
+        {
+            _local.Add(item);
+            return item;
+        }
+
+        public override T Create()
+        {
+            return Activator.CreateInstance<T>();
+        }
+
+        public override TDerivedEntity Create<TDerivedEntity>()
+        {
+            return Activator.CreateInstance<TDerivedEntity>();
+        }
+
+        #endregion Entity Operations
     }
 }


### PR DESCRIPTION
Add entity operations to DbSetStub.

EAS (on AML-2818-EnsureEventsForProviderRelationships branch) has been updated to use latest (this version) SFA.DAS.Testing.EntityFramework (with no regressions).
Changes required for and tested on SFA.DAS.ProviderRelationships' AML-2818-add-message-handlers branch.