### PR TITLE
ER-727 - Withdraw Application

### DIFF
--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/ApplicationWithdrawTests.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/ApplicationWithdrawTests.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace SFA.DAS.Recruit.Vacancies.Client.UnitTests
+{
+    [TestFixture]
+    public class ApplicationWithdrawTests
+    {
+        [Ignore("A helper test to add a message to the queue when debugging")]
+        [Test]
+        public void WithdrawApplication()
+        {
+            var sut = new Client(null, null, null, "UseDevelopmentStorage=true");
+
+            sut.WithdrawApplication(1234567890, Guid.NewGuid());
+        }
+    }
+}

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/SFA.DAS.Recruit.Vacancies.Client.UnitTests.csproj
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/SFA.DAS.Recruit.Vacancies.Client.UnitTests.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApplicationSubmitTests.cs" />
+    <Compile Include="ApplicationWithdrawTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VacancyVersionHelperTests.cs" />
   </ItemGroup>

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Client.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Client.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Authentication;
 using Microsoft.WindowsAzure.Storage;
@@ -17,6 +18,7 @@ namespace SFA.DAS.Recruit.Vacancies.Client
         private const string LiveVacancyDocumentType = "LiveVacancy";
         private const string IdFormat = "LiveVacancy_{0}";
         private const string ApplicationSubmittedQueueName = "application-submitted-queue";
+        private const string ApplicationWithdrawnQueueName = "application-withdrawn-queue";
 
         private readonly string _connectionString;
         private readonly string _databaseName;
@@ -78,6 +80,22 @@ namespace SFA.DAS.Recruit.Vacancies.Client
 
             var queue = GetQueue(ApplicationSubmittedQueueName);
             
+            queue.AddMessage(cloudQueueMessage);
+        }
+
+        public void WithdrawApplication(long vacancyReference, Guid candidateId)
+        {
+            var message = new ApplicationWithdrawMessage
+            {
+                CandidateId = candidateId,
+                VacancyReference = vacancyReference
+            };
+
+            var messageContent = JsonConvert.SerializeObject(message, Formatting.Indented);
+            var cloudQueueMessage = new CloudQueueMessage(messageContent);
+
+            var queue = GetQueue(ApplicationWithdrawnQueueName);
+
             queue.AddMessage(cloudQueueMessage);
         }
 

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/IClient.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/IClient.cs
@@ -1,4 +1,5 @@
-﻿using SFA.DAS.Recruit.Vacancies.Client.Entities;
+﻿using System;
+using SFA.DAS.Recruit.Vacancies.Client.Entities;
 using System.Collections.Generic;
 
 namespace SFA.DAS.Recruit.Vacancies.Client
@@ -8,5 +9,6 @@ namespace SFA.DAS.Recruit.Vacancies.Client
         LiveVacancy GetVacancy(long vacancyReference);
         IList<LiveVacancy> GetLiveVacancies();
         void SubmitApplication(Application application);
+        void WithdrawApplication(long vacancyReference, Guid candidateId);
     }
 }

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Messages/ApplicationWithdrawMessage.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Messages/ApplicationWithdrawMessage.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace SFA.DAS.Recruit.Vacancies.Client.Messages
+{
+    public class ApplicationWithdrawMessage
+    {
+        public Guid CandidateId { get; set; }
+        public long VacancyReference { get; set; }
+    }
+}

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.csproj
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Entities\Wage.cs" />
     <Compile Include="IClient.cs" />
     <Compile Include="Messages\ApplicationSubmitMessage.cs" />
+    <Compile Include="Messages\ApplicationWithdrawMessage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VacancyVersionHelper.cs" />
   </ItemGroup>


### PR DESCRIPTION
Added `WithdrawApplication` method to client which adds a message to the new `application-withdrawn-queue` queue.

Note - v2 is not aware of FAA's application Id. So we target applications by CandidateId/VacancyReference combo.