### PR TITLE
AML-2894 Log message contents

### DIFF
--- a/Messaging/SFA.DAS.Messaging.Tests/ObjectExtensionTests.cs
+++ b/Messaging/SFA.DAS.Messaging.Tests/ObjectExtensionTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace SFA.DAS.Messaging.UnitTests
+{
+    [TestFixture]
+    public class ObjectExtensionTests
+    {
+        [Test]
+        public void ToDictionary()
+        {
+            var testClass = new TestProperties1();
+            var dictionary = testClass.ToDictionary();
+
+            Assert.IsTrue(dictionary.ContainsKey(nameof(TestProperties1.IntProperty)));
+            Assert.IsTrue(dictionary.ContainsKey(nameof(TestProperties1.StringProperty)));
+            Assert.IsTrue(dictionary.ContainsKey(nameof(TestProperties1.ReadOnlyProperty)));
+        }
+    }
+
+    internal class TestProperties1
+    {
+        public string StringProperty { get; set; }
+        public int IntProperty { get; set; }
+        public DateTime ReadOnlyProperty => DateTime.Today;
+    }
+}

--- a/Messaging/SFA.DAS.Messaging.Tests/SFA.DAS.Messaging.UnitTests.csproj
+++ b/Messaging/SFA.DAS.Messaging.Tests/SFA.DAS.Messaging.UnitTests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Helpers\MessageGroupHelperTests\WhenIGetAMessageGroupNameFromObject.cs" />
     <Compile Include="MessageContextProviderTests.cs" />
     <Compile Include="MessageProcessorTests\WhenAMessageIsReceived.cs" />
+    <Compile Include="ObjectExtensionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Messaging/SFA.DAS.Messaging/MessageProcessor.cs
+++ b/Messaging/SFA.DAS.Messaging/MessageProcessor.cs
@@ -70,7 +70,7 @@ namespace SFA.DAS.Messaging
                             continue;
                         }
 
-                        Log.Debug($"Processing message of type {typeof(T).FullName}");
+                        Log.Debug($"Processing message of type {typeof(T).FullName}", message.Content.ToDictionary());
                         try
                         {
                             _messageContextProvider.StoreMessageContext(message);

--- a/Messaging/SFA.DAS.Messaging/ObjectExtensions.cs
+++ b/Messaging/SFA.DAS.Messaging/ObjectExtensions.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.Messaging
         /// <remarks>
         ///     This allows arbitrary objects to be provided to the logger (using the overloads that accept an IIDictionary)
         /// </remarks>
-        public static Dictionary<string, object> ToDictionary(this object obj)
+        public static IDictionary<string, object> ToDictionary(this object obj)
         {
             var properties = TypeCache.GetOrAdd(obj.GetType(), type => type.GetProperties());
 

--- a/Messaging/SFA.DAS.Messaging/ObjectExtensions.cs
+++ b/Messaging/SFA.DAS.Messaging/ObjectExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Messaging
+{
+    public static class ObjectExtensions
+    {
+        private static readonly ConcurrentDictionary<Type, PropertyInfo[]> TypeCache = new ConcurrentDictionary<Type, PropertyInfo[]>();
+
+        /// <summary>
+        ///     Converts the public properties on the supplied object to a case-insensitive dictionary.
+        /// </summary>
+        /// <remarks>
+        ///     This allows arbitrary objects to be provided to the logger (using the overloads that accept an IIDictionary)
+        /// </remarks>
+        public static Dictionary<string, object> ToDictionary(this object obj)
+        {
+            var properties = TypeCache.GetOrAdd(obj.GetType(), type => type.GetProperties());
+
+            return properties
+                .Select(propertyInfo => new
+                {
+                    Name = propertyInfo.Name,
+                    Value = propertyInfo.GetValue(obj, null)
+                })
+                .ToDictionary(ks => ks.Name, vs => vs.Value, StringComparer.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/Messaging/SFA.DAS.Messaging/SFA.DAS.Messaging.csproj
+++ b/Messaging/SFA.DAS.Messaging/SFA.DAS.Messaging.csproj
@@ -78,6 +78,7 @@
     <Compile Include="MessageContext.cs" />
     <Compile Include="MessageProcessor.cs" />
     <Compile Include="MessageReceivedEventArgs.cs" />
+    <Compile Include="ObjectExtensions.cs" />
     <Compile Include="PollingToEventSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Log non-null message contents received by message processors to allow better diagnostics when investigating message problems.