### PR TITLE
Add MessageProcessor2 to accept CancellationToken

### DIFF
--- a/Messaging/SFA.DAS.Messaging.Tests/MessageProcessor2Tests.cs
+++ b/Messaging/SFA.DAS.Messaging.Tests/MessageProcessor2Tests.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Messaging.Interfaces;
+using SFA.DAS.NLog.Logger;
+
+namespace SFA.DAS.Messaging.UnitTests
+{
+    [TestFixture]
+    public class MessageProcessor2Tests
+    {
+        public class MessageType
+        {
+        }
+
+        internal class TestMessageProcessor : MessageProcessor2<MessageType>
+        {
+            internal TestMessageProcessor(IMessageSubscriberFactory messageSubscriberFactory, ILog logger, IMessageContextProvider messageContextProvider) : base(messageSubscriberFactory, logger, messageContextProvider)
+            {
+            }
+
+            internal bool MessageProcessed;
+            internal bool ThrowException;
+            internal bool ExceptionHandled;
+
+            protected override async Task ProcessMessage(MessageType messageContent)
+            {
+                if (ThrowException)
+                {
+                    throw new Exception();
+                }
+
+                await Task.Run(() => { MessageProcessed = true; });
+            }
+
+            protected override async Task OnErrorAsync(IMessage<MessageType> message, Exception exception)
+            {
+                await Task.Run(() => { return ExceptionHandled = true; });
+            }
+        }
+
+        private Mock<IMessageSubscriberFactory> _messageSubscriberFactory;
+        private Mock<IMessageSubscriber<MessageType>> _messageSubscriber;
+        private Mock<IMessageContextProvider> _messageContextProvider;
+        private Mock<ILog> _logger;
+        private TestMessageProcessor _messageProcessor;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _messageSubscriber = new Mock<IMessageSubscriber<MessageType>>();
+            _messageSubscriberFactory = new Mock<IMessageSubscriberFactory>();
+            _messageContextProvider = new Mock<IMessageContextProvider>();
+            _logger = new Mock<ILog>();
+
+            _messageSubscriberFactory.Setup(x => x.GetSubscriber<MessageType>()).Returns(_messageSubscriber.Object);
+
+            _messageProcessor = new TestMessageProcessor(_messageSubscriberFactory.Object, _logger.Object, _messageContextProvider.Object);
+        }
+
+        [Test]
+        public void AndTheMessageIsNullThenNoProcessingIsDone()
+        {
+            _messageSubscriber.Setup(x => x.ReceiveAsAsync()).ReturnsAsync(null);
+
+            ProcessMessage(() => !_messageProcessor.MessageProcessed);
+            
+            Assert.IsFalse(_messageProcessor.MessageProcessed);
+        }
+
+        [Test]
+        public void AndTheMessageHasNoContentThenNoProcessingIsDoneAndTheMessageIsCompleted()
+        {
+            var message = new Mock<IMessage<MessageType>>();
+            _messageSubscriber.Setup(x => x.ReceiveAsAsync()).ReturnsAsync(message.Object);
+
+            ProcessMessage(() => !_messageProcessor.MessageProcessed);
+
+            Assert.IsFalse(_messageProcessor.MessageProcessed);
+            message.Verify(x => x.CompleteAsync());
+        }
+
+        [Test]
+        public void ThenTheMessageIsProcessedAndCompleted()
+        {
+            var message = new Mock<IMessage<MessageType>>();
+            message.SetupGet(x => x.Content).Returns(new MessageType());
+
+            _messageSubscriber.Setup(x => x.ReceiveAsAsync()).ReturnsAsync(message.Object);
+
+            ProcessMessage(() => _messageProcessor.MessageProcessed);
+
+            Assert.IsTrue(_messageProcessor.MessageProcessed);
+            message.Verify(x => x.CompleteAsync());
+        }
+
+        [Test]
+        public void ThenMessageIsStoredAndReleasedInAContext()
+        {
+            var message = new Mock<IMessage<MessageType>>();
+            message.SetupGet(x => x.Content).Returns(new MessageType());
+
+            _messageSubscriber.Setup(x => x.ReceiveAsAsync()).ReturnsAsync(message.Object);
+
+            ProcessMessage(() => _messageProcessor.MessageProcessed);
+
+            _messageContextProvider.Verify(mcp => mcp.StoreMessageContext(message.Object));
+            _messageContextProvider.Verify(mcp => mcp.ReleaseMessageContext(message.Object));
+        }
+
+        [Test]
+        public void AndAnErrorOccursThenTheErrorIsLoggedAndHandled()
+        {
+            _messageProcessor.ThrowException = true;
+            var message = new Mock<IMessage<MessageType>>();
+            message.SetupGet(x => x.Content).Returns(new MessageType());
+            _messageSubscriber.Setup(x => x.ReceiveAsAsync()).ReturnsAsync(message.Object);
+
+            ProcessMessage(() => _messageProcessor.ExceptionHandled);
+
+            _logger.Verify(x => x.Error(It.IsAny<Exception>(), $"Failed to process message {typeof(MessageType).FullName}"));
+
+            Assert.IsTrue(_messageProcessor.ExceptionHandled);
+            Assert.IsFalse(_messageProcessor.MessageProcessed);
+            message.Verify(x => x.CompleteAsync(), Times.Never);
+        }
+
+        private void ProcessMessage(Func<bool> condition)
+        {
+            var resetEvent=  new ManualResetEvent(false);
+            var cancellationTokenSource = new CancellationTokenSource();
+            Task.Run(() => _messageProcessor.RunAsync(cancellationTokenSource.Token), cancellationTokenSource.Token)
+                .ContinueWith(task => resetEvent.Set(), cancellationTokenSource.Token);
+
+            var timeout = DateTime.Now.AddSeconds(1);
+            while (DateTime.Now <= timeout)
+            {
+                Thread.Sleep(10);
+                if (condition())
+                {
+                    break;
+                }
+            }
+
+            cancellationTokenSource.Cancel();
+            resetEvent.WaitOne(1000);
+        }
+    }
+}

--- a/Messaging/SFA.DAS.Messaging.Tests/SFA.DAS.Messaging.UnitTests.csproj
+++ b/Messaging/SFA.DAS.Messaging.Tests/SFA.DAS.Messaging.UnitTests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Helpers\MessageGroupHelperTests\WhenIGetAMessageGroupNameFromType.cs" />
     <Compile Include="Helpers\MessageGroupHelperTests\WhenIGetAMessageGroupNameFromObject.cs" />
     <Compile Include="MessageContextProviderTests.cs" />
+    <Compile Include="MessageProcessor2Tests.cs" />
     <Compile Include="MessageProcessorTests\WhenAMessageIsReceived.cs" />
     <Compile Include="ObjectExtensionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Messaging/SFA.DAS.Messaging/Interfaces/IMessageProcessor2.cs
+++ b/Messaging/SFA.DAS.Messaging/Interfaces/IMessageProcessor2.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Messaging.Interfaces
+{
+    public interface IMessageProcessor2
+    {
+        Task RunAsync(CancellationToken cancellationToken);
+    }
+}

--- a/Messaging/SFA.DAS.Messaging/MessageProcessor.cs
+++ b/Messaging/SFA.DAS.Messaging/MessageProcessor.cs
@@ -6,6 +6,7 @@ using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.Messaging
 {
+    [Obsolete("Use MessageProcessor2 instead")]
     public abstract class MessageProcessor<T> : IMessageProcessor where T: class, new()
     {
         private readonly IMessageSubscriberFactory _messageSubscriberFactory;

--- a/Messaging/SFA.DAS.Messaging/MessageProcessor.cs
+++ b/Messaging/SFA.DAS.Messaging/MessageProcessor.cs
@@ -6,7 +6,7 @@ using SFA.DAS.NLog.Logger;
 
 namespace SFA.DAS.Messaging
 {
-    [Obsolete("Use MessageProcessor2 instead")]
+    [Obsolete("Use the MessageProcessor2 class instead as that will accept a more conventional cancellation token (rather than cancellation token source) and won't create large numbers of irrelevant log messages.")]
     public abstract class MessageProcessor<T> : IMessageProcessor where T: class, new()
     {
         private readonly IMessageSubscriberFactory _messageSubscriberFactory;

--- a/Messaging/SFA.DAS.Messaging/MessageProcessor2.cs
+++ b/Messaging/SFA.DAS.Messaging/MessageProcessor2.cs
@@ -13,6 +13,8 @@ namespace SFA.DAS.Messaging
 
         private readonly IMessageSubscriberFactory _messageSubscriberFactory;
         private readonly IMessageContextProvider _messageContextProvider;
+        private int _nullMessageCount = 0;
+        private int _nullMessageContentCount = 0;
         protected readonly ILog Log;
 
         protected MessageProcessor2(
@@ -82,9 +84,6 @@ namespace SFA.DAS.Messaging
 
             await HandleMessageWithContent(message);
         }
-
-        private int _nullMessageCount = 0;
-        private int _nullMessageContentCount = 0;
 
         private async Task<bool> IsNoMessage(IMessage<T> message, CancellationToken cancellationToken)
         {
@@ -157,7 +156,7 @@ namespace SFA.DAS.Messaging
             {
                 Log.Error(ex, $"Failed to process message {typeof(T).FullName}");
 
-                if (message != null && message.Content != null)
+                if (message?.Content != null)
                 {
                     await message.AbortAsync();
                 }

--- a/Messaging/SFA.DAS.Messaging/MessageProcessor2.cs
+++ b/Messaging/SFA.DAS.Messaging/MessageProcessor2.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SFA.DAS.Messaging.Interfaces;
+using SFA.DAS.NLog.Logger;
+
+namespace SFA.DAS.Messaging
+{
+    public abstract class MessageProcessor2<T> : IMessageProcessor2 where T: class, new()
+    {
+        // ReSharper disable once StaticMemberInGenericType
+        private static readonly Task CompletedTask = Task.Delay(0);
+
+        private readonly IMessageSubscriberFactory _messageSubscriberFactory;
+        private readonly IMessageContextProvider _messageContextProvider;
+        protected readonly ILog Log;
+
+        protected MessageProcessor2(
+            IMessageSubscriberFactory subscriberFactory, 
+            ILog log,
+            IMessageContextProvider messageContextProvider)
+        {
+            _messageSubscriberFactory = subscriberFactory;
+            Log = log;
+            _messageContextProvider = messageContextProvider;
+        }
+
+        public Task RunAsync(CancellationToken cancellationToken)
+        {
+            return Task.Run(() => Run(cancellationToken), cancellationToken);
+        }
+
+        public async Task Run(CancellationToken cancellationToken)
+        {
+            using (var subscriber = _messageSubscriberFactory.GetSubscriber<T>())
+            {
+                await ProcessMessagesUntilCancelled(subscriber, cancellationToken);
+            }
+        }
+
+        private async Task ProcessMessagesUntilCancelled(IMessageSubscriber<T> subscriber, CancellationToken cancellationToken)
+        {
+            StartBackgroundCountLogger(cancellationToken);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var message = await GetMessage(subscriber);
+                await ProcessMessage(message, cancellationToken);
+            }
+        }
+
+        private async Task<IMessage<T>> GetMessage(IMessageSubscriber<T> subscriber)
+        {
+            IMessage<T> message;
+            try
+            {
+                // This could throw an exception because the connection failed to open or a message could not be retrieved from the connection. We can't tell which 
+                // so we'll assume it is because the connection failed to open and abandon.
+                message = await subscriber.ReceiveAsAsync();
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, $"Failed to retrieve message {typeof(T).FullName}");
+                await OnFatalAsync(ex);
+                throw;
+            }
+
+            return message;
+        }
+
+        private async Task ProcessMessage(IMessage<T> message, CancellationToken cancellationToken)
+        {
+            if (await IsNoMessage(message, cancellationToken))
+            {
+                return;
+            }
+    
+            if (await IsNoMessageContent(message))
+            { 
+                return;
+            }
+
+            await HandleMessageWithContent(message);
+        }
+
+        private int _nullMessageCount = 0;
+        private int _nullMessageContentCount = 0;
+
+        private async Task<bool> IsNoMessage(IMessage<T> message, CancellationToken cancellationToken)
+        {
+            if (message == null)
+            {
+                Interlocked.Increment(ref _nullMessageCount);
+                await Task.Delay(500, cancellationToken);
+                return true;
+            }
+
+            return false;
+        }
+
+        private async Task<bool> IsNoMessageContent(IMessage<T> message)
+        {
+            if (message.Content == null)
+            {
+                Interlocked.Increment(ref _nullMessageContentCount);
+                Log.Debug($"Message {message.Id} of type {typeof(T).FullName} has null content - ignoring message");
+                await message.CompleteAsync();
+                return true;
+            }
+
+            return false;
+        }
+
+        private void StartBackgroundCountLogger(CancellationToken cancellationToken)
+        {
+            Task.Run(() => LogNulls(cancellationToken), cancellationToken);
+        }
+
+        private void LogNulls(CancellationToken cancellationToken)
+        {
+            var logInterval = new TimeSpan(0, 0, 1, 0);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                Task.Delay(logInterval, cancellationToken)
+                    .ContinueWith(task =>
+                    {
+                        var nullMessageCount = Interlocked.Exchange(ref _nullMessageCount, 0);
+                        var nullMessageContentCount = Interlocked.Exchange(ref _nullMessageContentCount, 0);
+
+                        Log.Debug(
+                            $"In the last {logInterval.TotalSeconds} seconds there have been {nullMessageCount} null messages of type {typeof(T).FullName} and {nullMessageContentCount} messages with null content");
+
+                    }, cancellationToken);
+            }
+        }
+
+        private async Task HandleMessageWithContent(IMessage<T> message)
+        {
+            try
+            {
+                Log.Debug($"Processing message of type {typeof(T).FullName}", message.Content.ToDictionary());
+                try
+                {
+                    _messageContextProvider.StoreMessageContext(message);
+                    await ProcessMessage(message.Content);
+                }
+                finally
+                {
+                    _messageContextProvider.ReleaseMessageContext(message);
+                }
+
+                await message.CompleteAsync();
+                Log.Info($"Completed message {typeof(T).FullName}");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"Failed to process message {typeof(T).FullName}");
+
+                if (message != null && message.Content != null)
+                {
+                    await message.AbortAsync();
+                }
+
+                await OnErrorAsync(message, ex);
+            }
+        }
+
+        /// <summary>
+        /// Implement to handle a message that needs to be processed
+        /// </summary>
+        /// <param name="messageContent"></param>
+        /// <returns></returns>
+        protected abstract Task ProcessMessage(T messageContent);
+
+        /// <summary>
+        /// Override to get error and message of this base class
+        /// </summary>
+        /// <param name="message">Message that has caused the error</param>
+        /// <param name="ex">Exception that has occurred</param>
+        /// <returns></returns>
+        protected virtual Task OnErrorAsync(IMessage<T> message, Exception ex)
+        {
+            //Do nothing unless someone overrides this method
+            return CompletedTask;
+        }
+
+        /// <summary>
+        /// Override to get fatal error of this base class
+        /// </summary>
+        /// <param name="ex">Exception of the fatal error</param>
+        /// <returns></returns>
+        protected virtual Task OnFatalAsync(Exception ex)
+        {
+            //Do nothing unless someone overrides this method
+            return CompletedTask;
+        }
+    }
+}

--- a/Messaging/SFA.DAS.Messaging/SFA.DAS.Messaging.csproj
+++ b/Messaging/SFA.DAS.Messaging/SFA.DAS.Messaging.csproj
@@ -70,12 +70,14 @@
     <Compile Include="Interfaces\IEventingMessageReceiver.cs" />
     <Compile Include="Interfaces\IMessage.cs" />
     <Compile Include="Interfaces\IMessageProcessor.cs" />
+    <Compile Include="Interfaces\IMessageProcessor2.cs" />
     <Compile Include="Interfaces\IMessagePublisher.cs" />
     <Compile Include="Interfaces\IMessageSubscriber.cs" />
     <Compile Include="Interfaces\IMessageSubscriberFactory.cs" />
     <Compile Include="MessageContextProvider.cs" />
     <Compile Include="Message.cs" />
     <Compile Include="MessageContext.cs" />
+    <Compile Include="MessageProcessor2.cs" />
     <Compile Include="MessageProcessor.cs" />
     <Compile Include="MessageReceivedEventArgs.cs" />
     <Compile Include="ObjectExtensions.cs" />


### PR DESCRIPTION
This provides an alternative to the existing MessageProcessor (imaginatively named MessageProcessor2) which doesn't accept a cancellation token source and does not seek to stop all other message handlers hanging on the same cancellation token source.