### PR TITLE
RA-2080 - Vacancy search client

### DIFF
--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/ApprenticeshipSearchClientTests.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/ApprenticeshipSearchClientTests.cs
@@ -1,0 +1,209 @@
+﻿using SFA.DAS.VacancyServices.Search.Requests;
+
+namespace SFA.DAS.VacancyServices.Search.UnitTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Entities;
+    using FluentAssertions;
+    using FluentAssertions.Json;
+    using Moq;
+    using Nest;
+    using Newtonsoft.Json.Linq;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ApprenticeshipSearchClientTests
+    {
+        [Test]
+        public void Search_ShouldSearchByLatAndLong()
+        {
+            var parameters = new ApprenticeshipSearchRequestParameters
+            {
+                ApprenticeshipLevel = "All",
+                Keywords = "baker",
+                Latitude = 52.4088862063274,
+                Longitude = 1.50554768088033,
+                PageNumber = 1,
+                PageSize = 5,
+                SearchField = ApprenticeshipSearchField.All,
+                SearchRadius = 40,
+                SortType = VacancySearchSortType.Distance,
+                VacancyLocationType = VacancyLocationType.NonNational
+            };
+
+            const string expectedJsonQuery = "{\"from\":0,\"size\":5,\"track_scores\":true,\"sort\":[{\"_geo_distance\":{\"location\":\"52.4088862063274, 1.50554768088033\",\"unit\":\"mi\"}}],\"aggs\":{\"SubCategoryCodes\":{\"terms\":{\"field\":\"subCategoryCode\",\"size\":0}}},\"query\":{\"bool\":{\"must\":[{\"bool\":{\"should\":[{\"match\":{\"title\":{\"query\":\"baker\",\"fuzziness\":1.0,\"prefix_length\":1,\"boost\":1.5,\"minimum_should_match\":\"100%\",\"operator\":\"and\"}}},{\"match\":{\"description\":{\"query\":\"baker\",\"fuzziness\":1.0,\"prefix_length\":1,\"slop\":2,\"boost\":1.0,\"minimum_should_match\":\"2<75%\"}}},{\"match\":{\"employerName\":{\"query\":\"baker\",\"fuzziness\":1.0,\"prefix_length\":1,\"boost\":5.0,\"minimum_should_match\":\"100%\",\"operator\":\"and\"}}}]}},{\"match\":{\"vacancyLocationType\":{\"query\":\"NonNational\"}}},{\"filtered\":{\"filter\":{\"geo_distance\":{\"location\":\"52.4088862063274, 1.50554768088033\",\"distance\":40.0,\"unit\":\"mi\"}}}}]}}}";
+            
+            AssertSearch(parameters, expectedJsonQuery);
+        }
+
+        [Test]
+        public void Search_ShouldSearchNationalApprenticeships()
+        {
+            var parameters = new ApprenticeshipSearchRequestParameters
+            {
+                ApprenticeshipLevel = "All",
+                Keywords = "baker",
+                PageNumber = 1,
+                PageSize = 5,
+                SearchField = ApprenticeshipSearchField.All,
+                SearchRadius = 40,
+                SortType = VacancySearchSortType.ClosingDate,
+                VacancyLocationType = VacancyLocationType.National
+            };
+
+            const string expectedJsonQuery = "{\"from\":0,\"size\":5,\"track_scores\":true,\"sort\":[{\"closingDate\":{\"order\":\"asc\"}}],\"aggs\":{\"SubCategoryCodes\":{\"terms\":{\"field\":\"subCategoryCode\",\"size\":0}}},\"query\":{\"bool\":{\"must\":[{\"bool\":{\"should\":[{\"match\":{\"title\":{\"query\":\"baker\",\"fuzziness\":1.0,\"prefix_length\":1,\"boost\":1.5,\"minimum_should_match\":\"100%\",\"operator\":\"and\"}}},{\"match\":{\"description\":{\"query\":\"baker\",\"fuzziness\":1.0,\"prefix_length\":1,\"slop\":2,\"boost\":1.0,\"minimum_should_match\":\"2<75%\"}}},{\"match\":{\"employerName\":{\"query\":\"baker\",\"fuzziness\":1.0,\"prefix_length\":1,\"boost\":5.0,\"minimum_should_match\":\"100%\",\"operator\":\"and\"}}}]}},{\"match\":{\"vacancyLocationType\":{\"query\":\"National\"}}}]}}}";
+
+            AssertSearch(parameters, expectedJsonQuery);
+        }
+
+        [Test]
+        public void Search_ShouldSearchByApprenticeshipLevelIfNotAll()
+        {
+            var parameters = new ApprenticeshipSearchRequestParameters
+            {
+                ApprenticeshipLevel = "Advanced",
+                PageNumber = 1,
+                PageSize = 5,
+                SearchField = ApprenticeshipSearchField.All,
+                SortType = VacancySearchSortType.ClosingDate,
+                VacancyLocationType = VacancyLocationType.National
+            };
+
+            const string expectedJsonQuery = "{\"from\":0,\"size\":5,\"track_scores\":true,\"sort\":[{\"closingDate\":{\"order\":\"asc\"}}],\"aggs\":{\"SubCategoryCodes\":{\"terms\":{\"field\":\"subCategoryCode\",\"size\":0}}},\"query\":{\"bool\":{\"must\":[{\"match\":{\"vacancyLocationType\":{\"query\":\"National\"}}},{\"match\":{\"apprenticeshipLevel\":{\"query\":\"Advanced\"}}}]}}}";
+
+            AssertSearch(parameters, expectedJsonQuery);
+        }
+
+        [Test]
+        public void Search_ShouldExcludeSpecifiedVacancies()
+        {
+            var parameters = new ApprenticeshipSearchRequestParameters
+            {
+                ApprenticeshipLevel = "All",
+                CategoryCode = "SSAT1.00",
+                ExcludeVacancyIds = new[] {123456, 789012},
+                Latitude = 52.4088862063274,
+                Longitude = -1.50554768088033,
+                PageNumber = 1,
+                PageSize = 5,
+                SearchField = ApprenticeshipSearchField.All,
+                SearchRadius = 5,
+                SortType = VacancySearchSortType.Distance,
+                VacancyLocationType = VacancyLocationType.NonNational
+            };
+
+            const string expectedJsonQuery = "{\"from\":0,\"size\":5,\"track_scores\":true,\"sort\":[{\"_geo_distance\":{\"location\":\"52.4088862063274, -1.50554768088033\",\"unit\":\"mi\"}}],\"aggs\":{\"SubCategoryCodes\":{\"terms\":{\"field\":\"subCategoryCode\",\"size\":0}}},\"query\":{\"bool\":{\"must\":[{\"terms\":{\"categoryCode\":[\"SSAT1.00\"]}},{\"match\":{\"vacancyLocationType\":{\"query\":\"NonNational\"}}},{\"filtered\":{\"filter\":{\"geo_distance\":{\"location\":\"52.4088862063274, -1.50554768088033\",\"distance\":5.0,\"unit\":\"mi\"}}}}],\"must_not\":[{\"ids\":{\"values\":[\"123456\",\"789012\"]}}]}}}";
+
+            AssertSearch(parameters, expectedJsonQuery);
+        }
+
+        [Test]
+        public void GetAllVacancyIds_ShouldScrollResults()
+        {
+            const string expectedJsonQuery = "{\"from\":0,\"size\":100,\"query\":{\"match_all\":{}}}";
+
+            var searchResponse = new Mock<ISearchResponse<ApprenticeshipSearchResult>>();
+            searchResponse.Setup(s => s.ScrollId).Returns("scrollId-100");
+
+            Func<SearchDescriptor<ApprenticeshipSearchResult>, SearchDescriptor<ApprenticeshipSearchResult>> actualSearchDescriptorFunc = null;
+
+            var mockClient = new Mock<IElasticClient>();
+
+            mockClient.Setup(c => c.Search<ApprenticeshipSearchResult>(It.IsAny<Func<SearchDescriptor<ApprenticeshipSearchResult>, SearchDescriptor<ApprenticeshipSearchResult>>>()))
+                .Callback<Func<SearchDescriptor<ApprenticeshipSearchResult>, SearchDescriptor<ApprenticeshipSearchResult>>>(d => actualSearchDescriptorFunc = d)
+                .Returns(searchResponse.Object);
+
+            var scrollResponse1 = new Mock<ISearchResponse<ApprenticeshipSearchResult>>();
+            scrollResponse1.Setup(r => r.Documents)
+                .Returns(new List<ApprenticeshipSearchResult>
+                {
+                    new ApprenticeshipSearchResult{Id = 3},
+                    new ApprenticeshipSearchResult{Id = 4}
+                });
+
+            var scrollResponse2 = new Mock<ISearchResponse<ApprenticeshipSearchResult>>();
+            scrollResponse2.Setup(r => r.Documents)
+                .Returns(new List<ApprenticeshipSearchResult>
+                {
+                    new ApprenticeshipSearchResult{Id = 5},
+                    new ApprenticeshipSearchResult{Id = 6}
+                });
+
+            var scrollResponse3 = new Mock<ISearchResponse<ApprenticeshipSearchResult>>();
+            scrollResponse3.Setup(r => r.Documents)
+                .Returns(Enumerable.Empty<ApprenticeshipSearchResult>());
+
+            mockClient.SetupSequence(c => c.Scroll<ApprenticeshipSearchResult>(It.Is<ScrollRequest>(r => r.ScrollId == "scrollId-100")))
+                .Returns(scrollResponse1.Object)
+                .Returns(scrollResponse2.Object)
+                .Returns(scrollResponse3.Object);
+
+            var factory = new Mock<IElasticSearchFactory>();
+            factory.Setup(f => f.GetElasticClient(It.IsAny<string>())).Returns(mockClient.Object);
+
+            var sut = new ApprenticeshipSearchClient(factory.Object, new VacancyServicesSearchConfiguration());
+
+            var actualResponse = sut.GetAllVacancyIds().ToList();
+
+            var baseSearchDescriptor = new SearchDescriptor<ApprenticeshipSearchResult>();
+            var query = actualSearchDescriptorFunc(baseSearchDescriptor);
+
+            var elasticClient = new ElasticClient();
+
+            var actualJsonQueryBytes = elasticClient.Serializer.Serialize(query);
+            var actualJsonQuery = System.Text.Encoding.UTF8.GetString(actualJsonQueryBytes.ToArray());
+
+            var actualJsonQueryJToken = JToken.Parse(actualJsonQuery);
+
+            var expectedJsonQueryJToken = JToken.Parse(expectedJsonQuery);
+
+            actualResponse.Count.Should().Be(4);
+            actualResponse[0].Should().Be(3);
+            actualResponse[1].Should().Be(4);
+            actualResponse[2].Should().Be(5);
+            actualResponse[3].Should().Be(6);
+
+            actualJsonQueryJToken.Should().BeEquivalentTo(expectedJsonQueryJToken);
+
+            mockClient.Verify(c => c.Scroll<ApprenticeshipSearchResult>(It.IsAny<ScrollRequest>()), Times.Exactly(3));
+        }
+
+        private void AssertSearch(ApprenticeshipSearchRequestParameters parameters, string expectedJsonQuery)
+        {
+            var searchResponse = new Mock<ISearchResponse<ApprenticeshipSearchResult>>();
+            searchResponse.Setup(s => s.Total).Returns(0);
+            searchResponse.Setup(s => s.Documents).Returns(Enumerable.Empty<ApprenticeshipSearchResult>());
+
+            Func<SearchDescriptor<ApprenticeshipSearchResult>, SearchDescriptor<ApprenticeshipSearchResult>> actualSearchDescriptorFunc = null;
+
+            var mockClient = new Mock<IElasticClient>();
+
+            mockClient.Setup(c => c.Search<ApprenticeshipSearchResult>(It.IsAny<Func<SearchDescriptor<ApprenticeshipSearchResult>, SearchDescriptor<ApprenticeshipSearchResult>>>()))
+                .Callback<Func<SearchDescriptor<ApprenticeshipSearchResult>, SearchDescriptor<ApprenticeshipSearchResult>>>(d => actualSearchDescriptorFunc = d)
+                .Returns(searchResponse.Object);
+
+            var factory = new Mock<IElasticSearchFactory>();
+            factory.Setup(f => f.GetElasticClient(It.IsAny<string>())).Returns(mockClient.Object);
+
+            var sut = new ApprenticeshipSearchClient(factory.Object, new VacancyServicesSearchConfiguration());
+
+            var response = sut.Search(parameters);
+
+            var baseSearchDescriptor = new SearchDescriptor<ApprenticeshipSearchResult>();
+            var query = actualSearchDescriptorFunc(baseSearchDescriptor);
+
+            var elasticClient = new ElasticClient();
+
+            var actualJsonQueryBytes = elasticClient.Serializer.Serialize(query);
+            var actualJsonQuery = System.Text.Encoding.UTF8.GetString(actualJsonQueryBytes.ToArray());
+
+            var actualJsonQueryJToken = JToken.Parse(actualJsonQuery);
+            
+            var expectedJsonQueryJToken = JToken.Parse(expectedJsonQuery);
+
+            actualJsonQueryJToken.Should().BeEquivalentTo(expectedJsonQueryJToken);
+        }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/LocationSearchClientTests.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/LocationSearchClientTests.cs
@@ -1,0 +1,98 @@
+﻿namespace SFA.DAS.VacancyServices.Search.UnitTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Entities;
+    using FluentAssertions;
+    using FluentAssertions.Json;
+    using Moq;
+    using Nest;
+    using Newtonsoft.Json.Linq;
+    using NUnit.Framework;
+
+    public class LocationClientTests
+    {
+        [Test]
+        public void Search_ShouldReturnOrderedResults()
+        {
+            LocationSearchClient sut = new TestLocationSearchClient();
+
+            const string searchTerm = "coventry";
+
+            var response = sut.Search(searchTerm);
+
+            var locations = response.Locations.ToList();
+
+            locations[0].Name.Should().Be("search-exact");
+            locations[1].Name.Should().Be("search-prefixed");
+            locations[2].Name.Should().Be("search-fuzzy");
+        }
+
+        [Test]
+        public void SearchExact_ShouldSearchForExactValues()
+        {
+            const string searchTerm = "coventry";
+
+            const string expectedJsonQuery = "{\"from\":0,\"size\":63,\"query\":{\"function_score\":{\"functions\":[{\"field_value_factor\":{\"field\":\"size\"}}],\"query\":{\"match\":{\"name\":{\"query\":\"coventry\"}}},\"score_mode\":\"sum\"}}}";
+
+            AssertSearch(c => c.SearchExact(searchTerm, 63), expectedJsonQuery);
+        }
+
+        [Test]
+        public void SearchPrefixed_ShouldSearchForPrefixedValues()
+        {
+            const string searchTerm = "coventry";
+
+            const string expectedJsonQuery = "{\"from\":0,\"size\":63,\"query\":{\"function_score\":{\"functions\":[{\"field_value_factor\":{\"field\":\"size\"}}],\"query\":{\"prefix\":{\"name\":{\"value\":\"coventry\"}}},\"score_mode\":\"sum\"}}}";
+
+            AssertSearch(c => c.SearchPrefixed(searchTerm, 63), expectedJsonQuery);
+        }
+
+        [Test]
+        public void SearchFuzzy_ShouldSearchForFuzzyMatchesValues()
+        {
+            const string searchTerm = "coventry";
+
+            const string expectedJsonQuery = "{\"from\":0,\"size\":63,\"query\":{\"function_score\":{\"functions\":[{\"field_value_factor\":{\"field\":\"size\"}}],\"query\":{\"bool\":{\"should\":[{\"fuzzy\":{\"name\":{\"prefix_length\":1,\"value\":\"coventry\",\"boost\":2.0}}},{\"fuzzy\":{\"county\":{\"prefix_length\":1,\"value\":\"coventry\",\"boost\":1.0}}}]}},\"score_mode\":\"sum\"}}}";
+
+            AssertSearch(c => c.SearchFuzzy(searchTerm, 63), expectedJsonQuery);
+        }
+
+        private void AssertSearch(Func<LocationSearchClient, IEnumerable<LocationSearchResult>> searchFunc, string expectedJsonQuery)
+        {
+            var searchReponse = new Mock<ISearchResponse<LocationSearchResult>>();
+            searchReponse.Setup(s => s.Total).Returns(0);
+            searchReponse.Setup(s => s.Documents).Returns(Enumerable.Empty<LocationSearchResult>());
+
+            Func<SearchDescriptor<LocationSearchResult>, SearchDescriptor<LocationSearchResult>> actualSearchDescriptorFunc = null;
+
+            var mockClient = new Mock<IElasticClient>();
+
+            mockClient.Setup(c => c.Search<LocationSearchResult>(It.IsAny<Func<SearchDescriptor<LocationSearchResult>, SearchDescriptor<LocationSearchResult>>>()))
+                .Callback<Func<SearchDescriptor<LocationSearchResult>, SearchDescriptor<LocationSearchResult>>>(d => actualSearchDescriptorFunc = d)
+                .Returns(searchReponse.Object);
+
+            var factory = new Mock<IElasticSearchFactory>();
+            factory.Setup(f => f.GetElasticClient(It.IsAny<string>())).Returns(mockClient.Object);
+
+            var sut = new LocationSearchClient(factory.Object, new VacancyServicesSearchConfiguration());
+
+            var response = searchFunc(sut);
+
+            var baseSearchDescriptor = new SearchDescriptor<LocationSearchResult>();
+            var query = actualSearchDescriptorFunc(baseSearchDescriptor);
+
+            var elasticClient = new ElasticClient();
+
+            var actualJsonQueryBytes = elasticClient.Serializer.Serialize(query);
+            var actualJsonQuery = System.Text.Encoding.UTF8.GetString(actualJsonQueryBytes.ToArray());
+
+            var actualJsonQueryJToken = JToken.Parse(actualJsonQuery);
+
+            var expectedJsonQueryJToken = JToken.Parse(expectedJsonQuery);
+
+            actualJsonQueryJToken.Should().BeEquivalentTo(expectedJsonQueryJToken);
+        }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/Properties/AssemblyInfo.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SFA.DAS.VacancyServices.Search.Framework452.IntegrationTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SFA.DAS.VacancyServices.Search.Framework452.IntegrationTests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("60d01c0f-cb86-4d06-b69c-4a92659a4ce2")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/SFA.DAS.VacancyServices.Search.UnitTests.csproj
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/SFA.DAS.VacancyServices.Search.UnitTests.csproj
@@ -1,0 +1,104 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{60D01C0F-CB86-4D06-B69C-4A92659A4CE2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SFA.DAS.VacancyServices.Search.UnitTests</RootNamespace>
+    <AssemblyName>SFA.DAS.VacancyServices.Search.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Elasticsearch.Net, Version=1.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.1.9.0\lib\net45\Elasticsearch.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Json, Version=4.20.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.Json.4.20.1\lib\net45\FluentAssertions.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.8.1\lib\net45\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="Nest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\NEST.1.9.0\lib\net45\Nest.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.4.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ApprenticeshipSearchClientTests.cs" />
+    <Compile Include="LocationSearchClientTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestLocationSearchClient.cs" />
+    <Compile Include="TraineeshipSearchClientTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.VacancyServices.Search\SFA.DAS.VacancyServices.Search.csproj">
+      <Project>{d59353af-e8fb-4238-954e-d2b7c62b23b8}</Project>
+      <Name>SFA.DAS.VacancyServices.Search</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+  </Target>
+</Project>

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/TestLocationSearchClient.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/TestLocationSearchClient.cs
@@ -1,0 +1,26 @@
+﻿namespace SFA.DAS.VacancyServices.Search.UnitTests
+{
+    using System.Collections.Generic;
+    using Entities;
+
+    public class TestLocationSearchClient : LocationSearchClient
+    {
+        public TestLocationSearchClient() : base(null, null) { }
+
+        public override IEnumerable<LocationSearchResult> SearchExact(string placeName, int maxResults = MaxResults)
+        {
+            return new[] { new LocationSearchResult { Name = "search-exact", Latitude = 1, Longitude = 1 } };
+        }
+
+        public override IEnumerable<LocationSearchResult> SearchPrefixed(string placeName, int maxResults = MaxResults)
+        {
+            return new[] { new LocationSearchResult { Name = "search-prefixed", Latitude = 2, Longitude = 2 } };
+        }
+
+        public override IEnumerable<LocationSearchResult> SearchFuzzy(string placeName, int maxResults = MaxResults)
+        {
+            return new[] { new LocationSearchResult { Name = "search-fuzzy", Latitude = 3, Longitude = 3 } };
+        }
+    }
+
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/TraineeshipSearchClientTests.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/TraineeshipSearchClientTests.cs
@@ -1,0 +1,163 @@
+﻿using SFA.DAS.VacancyServices.Search.Requests;
+
+namespace SFA.DAS.VacancyServices.Search.UnitTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using Entities;
+    using FluentAssertions;
+    using FluentAssertions.Json;
+    using Moq;
+    using Nest;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using NUnit.Framework;
+
+    public class TraineeshipSearchClientTests
+    {
+        [Test]
+        public void Search_ShouldSearchByLatAndLong()
+        {
+            var parameters = new TraineeshipSearchRequestParameters
+            {
+                Latitude = 52.4173666904458,
+                Longitude = -1.88983017452229,
+                PageNumber = 1,
+                PageSize = 5,
+                SearchRadius = 40,
+                SortType = VacancySearchSortType.Distance,
+            };
+
+            const string expectedJsonQuery = "{\"from\":0,\"size\":5,\"track_scores\":true,\"sort\":[{\"_geo_distance\":{\"location\":\"52.4173666904458, -1.88983017452229\",\"unit\":\"mi\"}}],\"query\":{\"filtered\":{\"filter\":{\"geo_distance\":{\"location\":\"52.4173666904458, -1.88983017452229\",\"distance\":40.0,\"unit\":\"mi\"}}}}}";
+
+            AssertSearch(parameters, expectedJsonQuery);
+        }
+
+        [Test]
+        public void Search_ShouldSearchByVacancyReference()
+        {
+            var parameters = new TraineeshipSearchRequestParameters
+            {
+                Latitude = 52.4173666904458,
+                Longitude = -1.88983017452229,
+                PageNumber = 1,
+                PageSize = 5,
+                SearchRadius = 40,
+                VacancyReference = "1104004"
+            };
+
+            const string expectedJsonQuery = "{\"from\":0,\"size\":5,\"track_scores\":true,\"query\":{\"filtered\":{\"filter\":{\"term\":{\"vacancyReference\":\"1104004\"}}}}}";
+
+            AssertSearch(parameters, expectedJsonQuery);
+        }
+
+        [Test]
+        public void GetAllVacancyIds_ShouldScrollResults()
+        {
+            const string expectedJsonQuery = "{\"from\":0,\"size\":100,\"query\":{\"match_all\":{}}}";
+
+            var searchResponse = new Mock<ISearchResponse<TraineeshipSearchResult>>();
+            searchResponse.Setup(s => s.ScrollId).Returns("scrollId-100");
+
+            Func<SearchDescriptor<TraineeshipSearchResult>, SearchDescriptor<TraineeshipSearchResult>> actualSearchDescriptorFunc = null;
+
+            var mockClient = new Mock<IElasticClient>();
+
+            mockClient.Setup(c => c.Search<TraineeshipSearchResult>(It.IsAny<Func<SearchDescriptor<TraineeshipSearchResult>, SearchDescriptor<TraineeshipSearchResult>>>()))
+                .Callback<Func<SearchDescriptor<TraineeshipSearchResult>, SearchDescriptor<TraineeshipSearchResult>>>(d => actualSearchDescriptorFunc = d)
+                .Returns(searchResponse.Object);
+
+            var scrollResponse1 = new Mock<ISearchResponse<TraineeshipSearchResult>>();
+            scrollResponse1.Setup(r => r.Documents)
+                .Returns(new List<TraineeshipSearchResult>
+                {
+                    new TraineeshipSearchResult{Id = 3},
+                    new TraineeshipSearchResult{Id = 4}
+                });
+
+            var scrollResponse2 = new Mock<ISearchResponse<TraineeshipSearchResult>>();
+            scrollResponse2.Setup(r => r.Documents)
+                .Returns(new List<TraineeshipSearchResult>
+                {
+                    new TraineeshipSearchResult{Id = 5},
+                    new TraineeshipSearchResult{Id = 6}
+                });
+
+            var scrollResponse3 = new Mock<ISearchResponse<TraineeshipSearchResult>>();
+            scrollResponse3.Setup(r => r.Documents)
+                .Returns(Enumerable.Empty<TraineeshipSearchResult>());
+
+            mockClient.SetupSequence(c => c.Scroll<TraineeshipSearchResult>(It.Is<ScrollRequest>(r => r.ScrollId == "scrollId-100")))
+                .Returns(scrollResponse1.Object)
+                .Returns(scrollResponse2.Object)
+                .Returns(scrollResponse3.Object);
+
+            var factory = new Mock<IElasticSearchFactory>();
+            factory.Setup(f => f.GetElasticClient(It.IsAny<string>())).Returns(mockClient.Object);
+
+            var sut = new TraineeshipSearchClient(factory.Object, new VacancyServicesSearchConfiguration());
+
+            var actualResponse = sut.GetAllVacancyIds().ToList();
+
+            var baseSearchDescriptor = new SearchDescriptor<TraineeshipSearchResult>();
+            var query = actualSearchDescriptorFunc(baseSearchDescriptor);
+
+            var elasticClient = new ElasticClient();
+
+            var actualJsonQueryBytes = elasticClient.Serializer.Serialize(query);
+            var actualJsonQuery = System.Text.Encoding.UTF8.GetString(actualJsonQueryBytes.ToArray());
+
+            var actualJsonQueryJToken = JToken.Parse(actualJsonQuery);
+
+            var expectedJsonQueryJToken = JToken.Parse(expectedJsonQuery);
+
+            actualResponse.Count.Should().Be(4);
+            actualResponse[0].Should().Be(3);
+            actualResponse[1].Should().Be(4);
+            actualResponse[2].Should().Be(5);
+            actualResponse[3].Should().Be(6);
+
+            actualJsonQueryJToken.Should().BeEquivalentTo(expectedJsonQueryJToken);
+
+            mockClient.Verify(c => c.Scroll<TraineeshipSearchResult>(It.IsAny<ScrollRequest>()), Times.Exactly(3));
+        }
+
+        private void AssertSearch(TraineeshipSearchRequestParameters parameters, string expectedJsonQuery)
+        {
+            var searchResponse = new Mock<ISearchResponse<TraineeshipSearchResult>>();
+            searchResponse.Setup(s => s.Total).Returns(0);
+            searchResponse.Setup(s => s.Documents).Returns(Enumerable.Empty<TraineeshipSearchResult>());
+
+            Func<SearchDescriptor<TraineeshipSearchResult>, SearchDescriptor<TraineeshipSearchResult>> actualSearchDescriptorFunc = null;
+
+            var mockClient = new Mock<IElasticClient>();
+
+            mockClient.Setup(c => c.Search<TraineeshipSearchResult>(It.IsAny<Func<SearchDescriptor<TraineeshipSearchResult>, SearchDescriptor<TraineeshipSearchResult>>>()))
+                .Callback<Func<SearchDescriptor<TraineeshipSearchResult>, SearchDescriptor<TraineeshipSearchResult>>>(d => actualSearchDescriptorFunc = d)
+                .Returns(searchResponse.Object);
+
+            var factory = new Mock<IElasticSearchFactory>();
+            factory.Setup(f => f.GetElasticClient(It.IsAny<string>())).Returns(mockClient.Object);
+
+            var sut = new TraineeshipSearchClient(factory.Object, new VacancyServicesSearchConfiguration());
+
+            var response = sut.Search(parameters);
+
+            var baseSearchDescriptor = new SearchDescriptor<TraineeshipSearchResult>();
+            var query = actualSearchDescriptorFunc(baseSearchDescriptor);
+
+            var elasticClient = new ElasticClient();
+
+            var actualJsonQueryBytes = elasticClient.Serializer.Serialize(query);
+            var actualJsonQuery = System.Text.Encoding.UTF8.GetString(actualJsonQueryBytes.ToArray());
+
+            var actualJsonQueryJToken = JToken.Parse(actualJsonQuery);
+
+            var expectedJsonQueryJToken = JToken.Parse(expectedJsonQuery);
+
+            actualJsonQueryJToken.Should().BeEquivalentTo(expectedJsonQueryJToken);
+        }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/app.config
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/app.config
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="FluentAssertions.Core" publicKeyToken="33f2691a05b67b6a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.19.4.0" newVersion="4.19.4.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/packages.config
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/packages.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
+  <package id="Elasticsearch.Net" version="1.9.0" targetFramework="net452" />
+  <package id="FluentAssertions" version="4.19.4" targetFramework="net452" />
+  <package id="FluentAssertions.Json" version="4.20.1" targetFramework="net452" />
+  <package id="Moq" version="4.8.1" targetFramework="net452" />
+  <package id="NEST" version="1.9.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="NUnit" version="3.10.1" targetFramework="net452" />
+  <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
+</packages>

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.sln
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2048
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.VacancyServices.Search", "SFA.DAS.VacancyServices.Search\SFA.DAS.VacancyServices.Search.csproj", "{715629F9-C44D-4D15-A4F7-CB02FA18429B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.VacancyServices.Search.UnitTests", "SFA.DAS.VacancyServices.Search.UnitTests\SFA.DAS.VacancyServices.Search.UnitTests.csproj", "{60D01C0F-CB86-4D06-B69C-4A92659A4CE2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{715629F9-C44D-4D15-A4F7-CB02FA18429B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{715629F9-C44D-4D15-A4F7-CB02FA18429B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{715629F9-C44D-4D15-A4F7-CB02FA18429B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{715629F9-C44D-4D15-A4F7-CB02FA18429B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60D01C0F-CB86-4D06-B69C-4A92659A4CE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60D01C0F-CB86-4D06-B69C-4A92659A4CE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60D01C0F-CB86-4D06-B69C-4A92659A4CE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60D01C0F-CB86-4D06-B69C-4A92659A4CE2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8DE42547-B2B8-439E-9C9D-C64319FC5DEE}
+	EndGlobalSection
+EndGlobal

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/ApprenticeshipSearchClient.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/ApprenticeshipSearchClient.cs
@@ -1,0 +1,396 @@
+﻿using SFA.DAS.VacancyServices.Search.Requests;
+
+namespace SFA.DAS.VacancyServices.Search
+{
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using Elasticsearch.Net;
+    using Entities;
+    using Nest;
+    using Newtonsoft.Json.Linq;
+    using Responses;
+
+    public class ApprenticeshipSearchClient : IApprenticeshipSearchClient
+    {
+        private const string SubCategoriesAggregationName = "SubCategoryCodes";
+
+        private const string ScrollIndexConsistencyTime = "5s";
+        private const int ScrollSize = 100;
+        private const string ScrollTimeout = "5s";
+
+        private readonly IElasticSearchFactory _elasticSearchFactory;
+        private readonly VacancyServicesSearchConfiguration _config;
+        private readonly SearchFactorConfiguration _searchFactorConfiguration;
+        private readonly IEnumerable<string> _keywordExcludedTerms;
+
+        public ApprenticeshipSearchClient(VacancyServicesSearchConfiguration config)
+        : this(new ElasticSearchFactory(), config)
+        {
+        }
+
+        internal ApprenticeshipSearchClient(IElasticSearchFactory elasticSearchFactory, VacancyServicesSearchConfiguration config)
+        {
+            _elasticSearchFactory = elasticSearchFactory;
+            _config = config;
+            _searchFactorConfiguration = GetSearchFactorConfiguration();
+            _keywordExcludedTerms = new[] {"apprenticeships", "apprenticeship", "traineeship", "traineeships", "trainee"};
+        }
+
+        public ApprenticeshipSearchResponse Search(ApprenticeshipSearchRequestParameters searchParameters)
+        {
+            SanitizeSearchParameters(searchParameters);
+
+            var results = PerformSearch(searchParameters);
+
+            SetPostSearchValues(searchParameters, results);
+
+            var aggregationResults = GetAggregationResultsFrom(results.Aggs);
+            var response = new ApprenticeshipSearchResponse(results.Total, results.Documents, aggregationResults, searchParameters);
+
+            return response;
+        }
+
+        public IEnumerable<int> GetAllVacancyIds()
+        {
+            var client = _elasticSearchFactory.GetElasticClient(_config.HostName);
+
+            var scanResults = client.Search<ApprenticeshipSearchResult>(search => search
+                .Index(_config.ApprenticeshipsIndex)
+                .Type(ElasticTypes.Apprenticeship)
+                .From(0)
+                .Size(ScrollSize)
+                .MatchAll()
+                .SearchType(SearchType.Scan)
+                .Scroll(ScrollIndexConsistencyTime));
+
+            var vacancyIds = new List<int>();
+            var scrollRequest = new ScrollRequest(scanResults.ScrollId, ScrollTimeout);
+
+            while (true)
+            {
+                var results = client.Scroll<ApprenticeshipSearchResult>(scrollRequest);
+
+                if (!results.Documents.Any())
+                {
+                    break;
+                }
+
+                vacancyIds.AddRange(results.Documents.Select(each => each.Id));
+            }
+
+            return vacancyIds;
+        }
+
+        private void SanitizeSearchParameters(ApprenticeshipSearchRequestParameters parameters)
+        {
+            if (!string.IsNullOrEmpty(parameters.Keywords))
+            {
+                parameters.Keywords = parameters.Keywords.ToLower();
+
+                foreach (var excludedTerm in _keywordExcludedTerms)
+                {
+                    parameters.Keywords = parameters.Keywords.Replace(excludedTerm, "");
+                }
+            }
+        }
+
+        private ISearchResponse<ApprenticeshipSearchResult> PerformSearch(ApprenticeshipSearchRequestParameters parameters)
+        {
+            var client = _elasticSearchFactory.GetElasticClient(_config.HostName);
+
+            var result = client.Search<ApprenticeshipSearchResult>(s =>
+            {
+                s.Index(_config.ApprenticeshipsIndex);
+                s.Type(ElasticTypes.Apprenticeship);
+                s.Skip((parameters.PageNumber - 1) * parameters.PageSize);
+                s.Take(parameters.PageSize);
+
+                s.TrackScores();
+
+                s.Query(q =>
+                {
+                    if(string.IsNullOrEmpty(parameters.VacancyReference))
+                        return GetQuery(parameters, q);
+
+                    return q.Filtered(sl =>
+                        sl.Filter(fs =>
+                            fs.Term(f =>
+                                f.VacancyReference, parameters.VacancyReference)));
+                });
+
+                switch (parameters.SortType)
+                {
+                    case VacancySearchSortType.RecentlyAdded:
+
+                        s.Sort(v => v.OnField(f => f.PostedDate).Descending());
+                        s.TrySortByGeoDistance(parameters);
+
+                        break;
+                    case VacancySearchSortType.Distance:
+
+                        s.TrySortByGeoDistance(parameters);
+
+                        break;
+                    case VacancySearchSortType.ClosingDate:
+
+                        s.Sort(v => v.OnField(f => f.ClosingDate).Ascending());
+                        s.TrySortByGeoDistance(parameters);
+                        
+                        break;
+                    case VacancySearchSortType.Relevancy:
+
+                        s.Fields("_source");
+                        if (parameters.IsLatLongSearch == false)
+                        {
+                            break;
+                        }
+                        s.ScriptFields(sf =>
+                            sf.Add("distance", sfd => sfd
+                                .Params(fp =>
+                                {
+                                    fp.Add(nameof(GeoPoint.lat), parameters.Latitude);
+                                    fp.Add(nameof(GeoPoint.lon), parameters.Longitude);
+                                    return fp;
+                                })
+                                .Script($"doc['location'].arcDistanceInMiles({nameof(GeoPoint.lat)}, {nameof(GeoPoint.lon)})")));
+                        break;
+                }
+
+                s.Aggregations(a => a.Terms(SubCategoriesAggregationName, st => st.Field(o => o.SubCategoryCode).Size(0)));
+
+                if (parameters.SubCategoryCodes != null && parameters.SubCategoryCodes.Any())
+                {
+                    var subCategoryCodes = new List<string>();
+
+                    subCategoryCodes.AddRange(parameters.SubCategoryCodes);
+
+                    s.Filter(ff => ff.Terms(f => f.SubCategoryCode, subCategoryCodes.Distinct()));
+                }
+
+                return s;
+            });
+
+            return result;
+        }
+
+        private QueryContainer GetQuery(ApprenticeshipSearchRequestParameters parameters, QueryDescriptor<ApprenticeshipSearchResult> q)
+        {
+            QueryContainer query = null;
+
+            if (!string.IsNullOrWhiteSpace(parameters.Keywords)
+                && (parameters.SearchField == ApprenticeshipSearchField.All || parameters.SearchField == ApprenticeshipSearchField.JobTitle))
+            {
+                var queryClause = q.Match(m =>
+                {
+                    m.OnField(f => f.Title).Query(parameters.Keywords);
+                    BuildFieldQuery(m, _searchFactorConfiguration.JobTitleFactors);
+                });
+
+                query = BuildContainer(null, queryClause);
+            }
+
+            if (!string.IsNullOrWhiteSpace(parameters.Keywords)
+                && (parameters.SearchField == ApprenticeshipSearchField.All || parameters.SearchField == ApprenticeshipSearchField.Description))
+            {
+                var queryClause = q.Match(m =>
+                {
+                    m.OnField(f => f.Description).Query(parameters.Keywords);
+                    BuildFieldQuery(m, _searchFactorConfiguration.DescriptionFactors);
+                });
+                query = BuildContainer(query, queryClause);
+            }
+
+            if (!string.IsNullOrWhiteSpace(parameters.Keywords)
+                && (parameters.SearchField == ApprenticeshipSearchField.All || parameters.SearchField == ApprenticeshipSearchField.Employer))
+            {
+                var exactMatchClause = q.Match(m =>
+                {
+                    m.OnField(f => f.EmployerName).Query(parameters.Keywords);
+                    BuildFieldQuery(m, _searchFactorConfiguration.EmployerFactors);
+                });
+                query = BuildContainer(query, exactMatchClause);
+            }
+
+            if (!string.IsNullOrWhiteSpace(parameters.CategoryCode))
+            {
+                var categoryCodes = new List<string>
+                        {
+                            parameters.CategoryCode
+                        };
+
+                var queryCategory = q.Terms(f => f.CategoryCode, categoryCodes.Distinct());
+
+                query = query && queryCategory;
+            }
+
+            if (parameters.ExcludeVacancyIds != null && parameters.ExcludeVacancyIds.Any())
+            {
+                var queryExcludeVacancyIds = !q.Ids(parameters.ExcludeVacancyIds.Select(x => x.ToString(CultureInfo.InvariantCulture)));
+                query = query && queryExcludeVacancyIds;
+            }
+
+            if (parameters.VacancyLocationType != VacancyLocationType.Unknown)
+            {
+                var queryVacancyLocation = q.Match(m => m.OnField(f => f.VacancyLocationType).Query(parameters.VacancyLocationType.ToString()));
+
+                query = query && queryVacancyLocation;
+            }
+
+            if (!string.IsNullOrWhiteSpace(parameters.ApprenticeshipLevel) && parameters.ApprenticeshipLevel != "All")
+            {
+                var queryClause = q
+                    .Match(m => m.OnField(f => f.ApprenticeshipLevel)
+                        .Query(parameters.ApprenticeshipLevel));
+                query = query && queryClause;
+            }
+
+            if (parameters.DisabilityConfidentOnly)
+            {
+                var queryDisabilityConfidentOnly = q.Match(m => m.OnField(f => f.IsDisabilityConfident)
+                                                                 .Query(parameters.DisabilityConfidentOnly.ToString()));
+                query = query && queryDisabilityConfidentOnly;
+            }
+
+            if (parameters.IsLatLongSearch && parameters.SearchRadius != 0)
+            {
+                var queryClause = q.Filtered(qf => qf.Filter(f => f
+                    .GeoDistance(vs => vs
+                        .Location, descriptor => descriptor
+                            .Location(parameters.Latitude.Value, parameters.Longitude.Value)
+                            .Distance(parameters.SearchRadius, GeoUnit.Miles))));
+                query = query && queryClause;
+            }
+
+            return query;
+        }
+
+        private QueryContainer BuildContainer(QueryContainer queryContainer, QueryContainer queryClause)
+        {
+            if (queryContainer == null)
+            {
+                queryContainer = queryClause;
+            }
+            else
+            {
+                queryContainer |= queryClause;
+            }
+
+            return queryContainer;
+        }
+
+        private static void BuildFieldQuery(MatchQueryDescriptor<ApprenticeshipSearchResult> queryDescriptor,
+            SearchTermFactors searchFactors)
+        {
+            if (searchFactors.Boost.HasValue)
+            {
+                queryDescriptor.Boost(searchFactors.Boost.Value);
+            }
+
+            if (searchFactors.Fuzziness.HasValue)
+            {
+                queryDescriptor.Fuzziness(searchFactors.Fuzziness.Value);
+            }
+
+            if (searchFactors.FuzzyPrefix.HasValue)
+            {
+                queryDescriptor.PrefixLength(searchFactors.FuzzyPrefix.Value);
+            }
+
+            if (searchFactors.MatchAllKeywords)
+            {
+                queryDescriptor.Operator(Operator.And);
+            }
+
+            if (!string.IsNullOrWhiteSpace(searchFactors.MinimumMatch))
+            {
+                queryDescriptor.MinimumShouldMatch(searchFactors.MinimumMatch);
+            }
+
+            if (searchFactors.PhraseProximity.HasValue)
+            {
+                queryDescriptor.Slop(searchFactors.PhraseProximity.Value);
+            }
+        }
+
+        private void SetPostSearchValues(ApprenticeshipSearchRequestParameters searchParameters, ISearchResponse<ApprenticeshipSearchResult> results)
+        {
+            foreach (var result in results.Documents)
+            {
+                var hitMd = results.HitsMetaData.Hits.First(h => h.Id == result.Id.ToString(CultureInfo.InvariantCulture));
+
+                if (searchParameters.IsLatLongSearch)
+                {
+                    if (searchParameters.SortType == VacancySearchSortType.ClosingDate ||
+                        searchParameters.SortType == VacancySearchSortType.Distance ||
+                        searchParameters.SortType == VacancySearchSortType.RecentlyAdded)
+                    {
+                        result.Distance = double.Parse(hitMd.Sorts.Skip(hitMd.Sorts.Count() - 1).First().ToString());
+                    }
+                    else
+                    {
+                        var array = hitMd.Fields.FieldValues<JArray>("distance");
+                        var value = array[0];
+
+                        result.Distance = double.Parse(value.ToString());
+                    }
+                }
+
+                result.Score = hitMd.Score;
+            }
+        }
+
+        private static IEnumerable<AggregationResult> GetAggregationResultsFrom(AggregationsHelper aggregations)
+        {
+            if (aggregations == null)
+                return Enumerable.Empty<AggregationResult>();
+
+            var terms = aggregations.Terms(SubCategoriesAggregationName);
+
+            if (terms == null)
+            {
+                return Enumerable.Empty<AggregationResult>();
+            }
+
+            var items = terms.Items.Select(bucket => new AggregationResult
+            {
+                Code = bucket.Key,
+                Count = bucket.DocCount
+            });
+
+            return items;
+        }
+
+        private static SearchFactorConfiguration GetSearchFactorConfiguration()
+        {
+            return new SearchFactorConfiguration
+            {
+                JobTitleFactors = new SearchTermFactors
+                {
+                    Boost = 1.5d,
+                    Fuzziness = 1,
+                    FuzzyPrefix = 1,
+                    MatchAllKeywords = true,
+                    MinimumMatch = "100%"
+                },
+                EmployerFactors = new SearchTermFactors
+                {
+                    Boost = 5,
+                    Fuzziness = 1,
+                    FuzzyPrefix = 1,
+                    MatchAllKeywords = true,
+                    MinimumMatch = "100%"
+                },
+                DescriptionFactors = new SearchTermFactors
+                {
+                    Boost = 1.0d,
+                    Fuzziness = 1,
+                    FuzzyPrefix = 1,
+                    MatchAllKeywords = false,
+                    MinimumMatch = "2<75%",
+                    PhraseProximity = 2
+                }
+            };
+        }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/ElasticSearchFactory.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/ElasticSearchFactory.cs
@@ -1,0 +1,17 @@
+﻿namespace SFA.DAS.VacancyServices.Search
+{
+    using System;
+    using Nest;
+    using Newtonsoft.Json.Converters;
+
+    internal class ElasticSearchFactory : IElasticSearchFactory
+    {
+        public IElasticClient GetElasticClient(string hostName)
+        {
+            var elasticConnectionSettings = new ConnectionSettings(new Uri(hostName));
+            elasticConnectionSettings.AddContractJsonConverters(t => typeof(Enum).IsAssignableFrom(t) ? new StringEnumConverter() : null);
+
+            return new ElasticClient(elasticConnectionSettings);
+        }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/ElasticTypes.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/ElasticTypes.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.VacancyServices.Search
+{
+    internal static class ElasticTypes
+    {
+        public const string Apprenticeship = "apprenticeship";
+        public const string Traineeship = "traineeship";
+        public const string Location = "locationdatas";
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/AggregationResult.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/AggregationResult.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.VacancyServices.Search.Entities
+{
+    public class AggregationResult
+    {
+        public string Code { get; set; }
+        public long Count { get; set; }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/ApprenticeshipLevel.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/ApprenticeshipLevel.cs
@@ -1,0 +1,13 @@
+﻿namespace SFA.DAS.VacancyServices.Search.Entities
+{
+    public enum ApprenticeshipLevel
+    {
+        Unknown = 0,
+        Intermediate,
+        Advanced,
+        Higher,
+        Degree,
+        Foundation,
+        Masters
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/ApprenticeshipSearchField.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/ApprenticeshipSearchField.cs
@@ -1,0 +1,12 @@
+﻿namespace SFA.DAS.VacancyServices.Search.Entities
+{
+    public enum ApprenticeshipSearchField
+    {
+        All,
+        JobTitle,
+        Description,
+        Employer,
+        Provider,
+        ReferenceNumber
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/ApprenticeshipSearchResult.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/ApprenticeshipSearchResult.cs
@@ -1,0 +1,45 @@
+﻿namespace SFA.DAS.VacancyServices.Search.Entities
+{
+    using System;
+
+    public class ApprenticeshipSearchResult
+    {
+        public int Id { get; set; }
+
+        public string AnonymousEmployerName { get; set; }
+        public ApprenticeshipLevel ApprenticeshipLevel { get; set; }
+        public string Category { get; set; }
+        public string CategoryCode { get; set; }
+        public DateTime ClosingDate { get; set; }
+        public string Description { get; set; }
+        public string EmployerName { get; set; }
+        public string FrameworkLarsCode { get; set; }
+        public decimal? HoursPerWeek { get; set; }
+        public bool IsDisabilityConfident { get; set; }
+        public bool IsEmployerAnonymous { get; set; }
+        public bool IsPositiveAboutDisability { get; set; }
+        public bool IsRecruitVacancy { get; set; }
+        public GeoPoint Location { get; set; }
+        public int NumberOfPositions { get; set; }
+        public DateTime PostedDate { get; set; }
+        public string ProviderName { get; set; }
+        public int? StandardLarsCode { get; set; }
+        public DateTime StartDate { get; set; }
+        public string SubCategory { get; set; }
+        public string SubCategoryCode { get; set; }
+        public string Title { get; set; }
+        public VacancyLocationType VacancyLocationType { get; set; }
+        public string VacancyReference { get; set; }
+        public decimal? WageAmount { get; set; }
+        public decimal? WageAmountLowerBound { get; set; }
+        public decimal? WageAmountUpperBound { get; set; }
+        public string WageText { get; set; }
+        public int WageUnit { get; set; }
+        public int WageType { get; set; }
+        public string WorkingWeek { get; set; }
+        
+        //Calculated after search
+        public double Distance { get; set; }
+        public double Score { get; set; }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/GeoPoint.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/GeoPoint.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.VacancyServices.Search.Entities
+{
+    public class GeoPoint
+    {
+        public double lon { get; set; }
+        public double lat { get; set; }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/LocationSearchResult.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/LocationSearchResult.cs
@@ -1,0 +1,11 @@
+﻿namespace SFA.DAS.VacancyServices.Search.Entities
+{
+    public class LocationSearchResult
+    {
+        public string Name { get; set; }
+        public string County { get; set; }
+        public double Longitude { get; set; }
+        public double Latitude { get; set; }
+        public double Size { get; set; }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/TraineeshipSearchResult.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/TraineeshipSearchResult.cs
@@ -1,0 +1,31 @@
+﻿namespace SFA.DAS.VacancyServices.Search.Entities
+{
+    using System;
+
+    public class TraineeshipSearchResult
+    {
+        public int Id { get; set; }
+        public string AnonymousEmployerName { get; set; }
+        public string Category { get; set; }
+        public string CategoryCode { get; set; }
+        public DateTime ClosingDate { get; set; }
+        public string Description { get; set; }
+        public string EmployerName { get; set; }
+        public bool IsDisabilityConfident { get; set; }
+        public bool IsEmployerAnonymous { get; set; }
+        public bool IsPositiveAboutDisability { get; set; }
+        public GeoPoint Location { get; set; }
+        public int NumberOfPositions { get; set; }
+        public DateTime PostedDate { get; set; }
+        public string ProviderName { get; set; }
+        public DateTime StartDate { get; set; }
+        public string SubCategory { get; set; }
+        public string SubCategoryCode { get; set; }
+        public string Title { get; set; }
+        public string VacancyReference { get; set; }
+
+        //Calculated after search
+        public double Distance { get; set; }
+        public double Score { get; set; }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/VacancyLocationType.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Entities/VacancyLocationType.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.VacancyServices.Search.Entities
+{
+    public enum VacancyLocationType
+    {
+        Unknown = 0,
+        NonNational,
+        National
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Extensions/SearchDescriptorExtensions.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Extensions/SearchDescriptorExtensions.cs
@@ -1,0 +1,40 @@
+﻿using SFA.DAS.VacancyServices.Search.Requests;
+
+namespace SFA.DAS.VacancyServices.Search
+{
+    using Entities;
+    using Nest;
+
+    internal static class SearchDescriptorExtensions
+    {
+        internal static SearchDescriptor<ApprenticeshipSearchResult> TrySortByGeoDistance(this SearchDescriptor<ApprenticeshipSearchResult> searchDescriptor, ApprenticeshipSearchRequestParameters searchParameters)
+        {
+            if (searchParameters.IsLatLongSearch)
+            {
+                searchDescriptor.SortGeoDistance(g =>
+                {
+                    g.PinTo(searchParameters.Latitude.Value, searchParameters.Longitude.Value)
+                        .Unit(GeoUnit.Miles).OnField(f => f.Location);
+                    return g;
+                });
+            }
+
+            return searchDescriptor;
+        }
+
+        internal static SearchDescriptor<TraineeshipSearchResult> TrySortByGeoDistance(this SearchDescriptor<TraineeshipSearchResult> searchDescriptor, TraineeshipSearchRequestParameters searchParameters)
+        {
+            if (searchParameters.IsLatLongSearch)
+            {
+                searchDescriptor.SortGeoDistance(g =>
+                {
+                    g.PinTo(searchParameters.Latitude.Value, searchParameters.Longitude.Value)
+                        .Unit(GeoUnit.Miles).OnField(f => f.Location);
+                    return g;
+                });
+            }
+
+            return searchDescriptor;
+        }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/IApprenticeshipSearchClient.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/IApprenticeshipSearchClient.cs
@@ -1,0 +1,13 @@
+﻿using SFA.DAS.VacancyServices.Search.Requests;
+
+namespace SFA.DAS.VacancyServices.Search
+{
+    using Responses;
+    using System.Collections.Generic;
+
+    public interface IApprenticeshipSearchClient
+    {
+        ApprenticeshipSearchResponse Search(ApprenticeshipSearchRequestParameters searchParameters);
+        IEnumerable<int> GetAllVacancyIds();
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/IElasticSearchFactory.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/IElasticSearchFactory.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.VacancyServices.Search
+{
+    using Nest;
+
+    internal interface IElasticSearchFactory
+    {
+        IElasticClient GetElasticClient(string hostName);
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/ILocationSearchClient.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/ILocationSearchClient.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.VacancyServices.Search
+{
+    using Responses;
+
+    public interface ILocationSearchClient
+    {
+        LocationSearchResponse Search(string placeName, int maxResults = LocationSearchClient.MaxResults);
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/ITraineeshipSearchClient.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/ITraineeshipSearchClient.cs
@@ -1,0 +1,13 @@
+﻿using SFA.DAS.VacancyServices.Search.Requests;
+
+namespace SFA.DAS.VacancyServices.Search
+{
+    using System.Collections.Generic;
+    using Responses;
+
+    public interface ITraineeshipSearchClient
+    {
+        TraineeshipSearchResponse Search(TraineeshipSearchRequestParameters searchParameters);
+        IEnumerable<int> GetAllVacancyIds();
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/InternalsVisibleTo.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/InternalsVisibleTo.cs
@@ -1,0 +1,4 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+[assembly: InternalsVisibleTo("SFA.DAS.VacancyServices.Search.UnitTests")]

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/LocationSearchClient.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/LocationSearchClient.cs
@@ -1,0 +1,117 @@
+﻿namespace SFA.DAS.VacancyServices.Search
+{
+    using Entities;
+    using Nest;
+    using Responses;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public class LocationSearchClient : ILocationSearchClient
+    {
+        public const int MaxResults = 50;
+        private readonly IElasticSearchFactory _elasticSearchFactory;
+        private readonly VacancyServicesSearchConfiguration _config;
+
+        public LocationSearchClient(VacancyServicesSearchConfiguration config)
+            : this(new ElasticSearchFactory(), config)
+        {
+        }
+
+        internal LocationSearchClient(IElasticSearchFactory elasticSearchFactory, VacancyServicesSearchConfiguration config)
+        {
+            _elasticSearchFactory = elasticSearchFactory;
+            _config = config;
+        }
+
+        public LocationSearchResponse Search(string placeName, int maxResults = MaxResults)
+        {
+            var exactMatchResults = SearchExact(placeName, maxResults);
+            var prefixMatchResults = SearchPrefixed(placeName, maxResults);
+            var fuzzyMatchResults = SearchFuzzy(placeName, maxResults);
+
+            // Prefer exact matches over prefix matches; prefer prefix matches over fuzzy matches.
+            var results =
+                exactMatchResults
+                    .Concat(prefixMatchResults)
+                    .Concat(fuzzyMatchResults)
+                    .Distinct((new LocationComparer()))
+                    .Take(maxResults)
+                    .ToList();
+
+            return new LocationSearchResponse {Locations = results};
+        }
+
+        public virtual IEnumerable<LocationSearchResult> SearchExact(string placeName, int maxResults = MaxResults)
+        {
+            var client = _elasticSearchFactory.GetElasticClient(_config.HostName);
+            var term = placeName.ToLowerInvariant();
+
+            var exactMatchResults = client.Search<LocationSearchResult>(s => s
+                .Index(_config.LocationsIndex)
+                .Type(ElasticTypes.Location)
+                .Query(q1 => q1
+                    .FunctionScore(fs => fs.Query(q2 => q2
+                            .Match(m => m.OnField(f => f.Name).Query(term)))
+                        .Functions(f => f.FieldValueFactor(fvf => fvf.Field(ll => ll.Size))).ScoreMode(FunctionScoreMode.Sum))
+                )
+                .From(0)
+                .Size(maxResults));
+
+
+            return exactMatchResults.Documents;
+        }
+
+        public virtual IEnumerable<LocationSearchResult> SearchPrefixed(string placeName, int maxResults = MaxResults)
+        {
+            var client = _elasticSearchFactory.GetElasticClient(_config.HostName);
+            var term = placeName.ToLowerInvariant();
+
+            var prefixMatchResults = client.Search<LocationSearchResult>(s => s
+                .Index(_config.LocationsIndex)
+                .Type(ElasticTypes.Location)
+                .Query(q1 => q1
+                    .FunctionScore(fs => fs.Query(q2 => q2
+                            .Prefix(p => p.OnField(n => n.Name).Value(term)))
+                        .Functions(f => f.FieldValueFactor(fvf => fvf.Field(ll => ll.Size))).ScoreMode(FunctionScoreMode.Sum))
+                )
+                .From(0)
+                .Size(maxResults));
+
+            return prefixMatchResults.Documents;
+        }
+
+        public virtual IEnumerable<LocationSearchResult> SearchFuzzy(string placeName, int maxResults = MaxResults)
+        {
+            var client = _elasticSearchFactory.GetElasticClient(_config.HostName);
+            var term = placeName.ToLowerInvariant();
+
+            var fuzzyMatchResults = client.Search<LocationSearchResult>(s => s
+                .Index(_config.LocationsIndex)
+                .Type(ElasticTypes.Location)
+                .Query(q1 => q1
+                    .FunctionScore(fs => fs.Query(q2 =>
+                            q2.Fuzzy(f => f.PrefixLength(1).OnField(n => n.Name).Value(term).Boost(2.0)) ||
+                            q2.Fuzzy(f => f.PrefixLength(1).OnField(n => n.County).Value(term).Boost(1.0)))
+                        .Functions(f => f.FieldValueFactor(fvf => fvf.Field(ll => ll.Size))).ScoreMode(FunctionScoreMode.Sum))
+                )
+                .From(0)
+                .Size(maxResults));
+
+            return fuzzyMatchResults.Documents;
+        }
+
+        private class LocationComparer : IEqualityComparer<LocationSearchResult>
+        {
+            public bool Equals(LocationSearchResult g1, LocationSearchResult g2)
+            {
+                return g1.Latitude.Equals(g2.Latitude) &&
+                       g1.Longitude.Equals(g2.Longitude);
+            }
+
+            public int GetHashCode(LocationSearchResult obj)
+            {
+                return string.Format("{0},{1}", obj.Longitude, obj.Latitude).ToLower().GetHashCode();
+            }
+        }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Requests/ApprenticeshipSearchRequestParameters.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Requests/ApprenticeshipSearchRequestParameters.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using SFA.DAS.VacancyServices.Search.Entities;
+
+namespace SFA.DAS.VacancyServices.Search.Requests
+{
+    public class ApprenticeshipSearchRequestParameters
+    {
+        public string ApprenticeshipLevel { get; set; }
+        public string CategoryCode { get; set; }
+        public bool DisabilityConfidentOnly { get; set; }
+        public IEnumerable<int> ExcludeVacancyIds { get; set; }
+        public string Keywords { get; set; }
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
+        public ApprenticeshipSearchField SearchField { get; set; }
+        public int SearchRadius { get; set; }
+        public VacancySearchSortType SortType { get; set; }
+        public string[] SubCategoryCodes { get; set; }
+        public VacancyLocationType VacancyLocationType { get; set; }
+        public string VacancyReference { get; set; }
+
+        public bool IsLatLongSearch => Latitude.HasValue && Longitude.HasValue;
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Requests/TraineeshipSearchRequestParameters.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Requests/TraineeshipSearchRequestParameters.cs
@@ -1,0 +1,15 @@
+﻿namespace SFA.DAS.VacancyServices.Search.Requests
+{
+    public class TraineeshipSearchRequestParameters
+    {
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
+        public int SearchRadius { get; set; }
+        public VacancySearchSortType SortType { get; set; }
+        public string VacancyReference { get; set; }
+
+        public bool IsLatLongSearch => Latitude.HasValue && Longitude.HasValue;
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Requests/VacancySearchSortType.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Requests/VacancySearchSortType.cs
@@ -1,0 +1,10 @@
+﻿namespace SFA.DAS.VacancyServices.Search.Requests
+{
+    public enum VacancySearchSortType
+    {
+        Relevancy,
+        Distance,
+        ClosingDate,
+        RecentlyAdded
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Responses/ApprenticeshipSearchResponse.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Responses/ApprenticeshipSearchResponse.cs
@@ -1,0 +1,27 @@
+﻿using SFA.DAS.VacancyServices.Search.Requests;
+
+namespace SFA.DAS.VacancyServices.Search.Responses
+{
+    using System.Collections.Generic;
+    using Entities;
+
+    public class ApprenticeshipSearchResponse
+    {
+        public ApprenticeshipSearchResponse(
+            long total,
+            IEnumerable<ApprenticeshipSearchResult> results, 
+            IEnumerable<AggregationResult> aggregationResults,
+            ApprenticeshipSearchRequestParameters searchParameters)
+        {
+            Total = total;
+            Results = results;
+            AggregationResults = aggregationResults;
+            SearchParameters = searchParameters;
+        }
+
+        public long Total { get;}
+        public IEnumerable<ApprenticeshipSearchResult> Results { get;}
+        public IEnumerable<AggregationResult> AggregationResults { get;}
+        public ApprenticeshipSearchRequestParameters SearchParameters { get;}
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Responses/LocationSearchResponse.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Responses/LocationSearchResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace SFA.DAS.VacancyServices.Search.Responses
+{
+    using Entities;
+    using System.Collections.Generic;
+
+    public class LocationSearchResponse
+    {
+        public List<LocationSearchResult> Locations { get; set; }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Responses/TraineeshipSearchResponse.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Responses/TraineeshipSearchResponse.cs
@@ -1,0 +1,24 @@
+﻿using SFA.DAS.VacancyServices.Search.Requests;
+
+namespace SFA.DAS.VacancyServices.Search.Responses
+{
+    using System.Collections.Generic;
+    using Entities;
+
+    public class TraineeshipSearchResponse
+    {
+        public TraineeshipSearchResponse(
+            long total,
+            IEnumerable<TraineeshipSearchResult> results, 
+            TraineeshipSearchRequestParameters searchParameters)
+        {
+            Total = total;
+            Results = results;
+            SearchParameters = searchParameters;
+        }
+
+        public long Total { get;}
+        public IEnumerable<TraineeshipSearchResult> Results { get;}
+        public TraineeshipSearchRequestParameters SearchParameters { get;}
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.csproj
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net452</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseUrl>https://github.com/SkillsFundingAgency/das-shared-packages/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/SkillsFundingAgency/das-shared-packages</PackageProjectUrl>
+    <Authors>DAS</Authors>
+    <Description>Client package to search for Apprenticeship &amp; Traineeship vacancies</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NEST" Version="1.9.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/SearchFactorConfiguration.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/SearchFactorConfiguration.cs
@@ -1,0 +1,26 @@
+﻿namespace SFA.DAS.VacancyServices.Search
+{
+    internal class SearchFactorConfiguration
+    {
+        public SearchTermFactors JobTitleFactors { get; set; }
+
+        public SearchTermFactors EmployerFactors { get; set; }
+
+        public SearchTermFactors DescriptionFactors { get; set; }
+    }
+
+    internal class SearchTermFactors
+    {
+        public double? Boost { get; set; }
+
+        public int? Fuzziness { get; set; }
+
+        public int? FuzzyPrefix { get; set; }
+
+        public bool MatchAllKeywords { get; set; }
+
+        public int? PhraseProximity { get; set; }
+
+        public string MinimumMatch { get; set; }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/TraineeshipSearchClient.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/TraineeshipSearchClient.cs
@@ -1,0 +1,163 @@
+﻿using SFA.DAS.VacancyServices.Search.Requests;
+
+namespace SFA.DAS.VacancyServices.Search
+{
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using Elasticsearch.Net;
+    using Entities;
+    using Nest;
+    using Responses;
+
+    public class TraineeshipSearchClient : ITraineeshipSearchClient
+    {
+        private const string ScrollIndexConsistencyTime = "5s";
+        private const int ScrollSize = 100;
+        private const string ScrollTimeout = "5s";
+
+        private readonly IElasticSearchFactory _elasticSearchFactory;
+        private readonly VacancyServicesSearchConfiguration _config;
+
+        public TraineeshipSearchClient(VacancyServicesSearchConfiguration config)
+            : this(new ElasticSearchFactory(), config)
+        {
+        }
+
+        internal TraineeshipSearchClient(IElasticSearchFactory elasticSearchFactory, VacancyServicesSearchConfiguration config)
+        {
+            _elasticSearchFactory = elasticSearchFactory;
+            _config = config;
+        }
+
+        public IEnumerable<int> GetAllVacancyIds()
+        {
+            var client = _elasticSearchFactory.GetElasticClient(_config.HostName);
+
+            var scanResults = client.Search<TraineeshipSearchResult>(search => search
+                .Index(_config.TraineeshipsIndex)
+                .Type(ElasticTypes.Traineeship)
+                .From(0)
+                .Size(ScrollSize)
+                .MatchAll()
+                .SearchType(SearchType.Scan)
+                .Scroll(ScrollIndexConsistencyTime));
+
+            var vacancyIds = new List<int>();
+            var scrollRequest = new ScrollRequest(scanResults.ScrollId, ScrollTimeout);
+
+            while (true)
+            {
+                var results = client.Scroll<TraineeshipSearchResult>(scrollRequest);
+
+                if (!results.Documents.Any())
+                {
+                    break;
+                }
+
+                vacancyIds.AddRange(results.Documents.Select(each => each.Id));
+            }
+
+            return vacancyIds;
+        }
+
+        public TraineeshipSearchResponse Search(TraineeshipSearchRequestParameters searchParameters)
+        {
+            var results = PerformSearch(searchParameters);
+
+            SetPostSearchValues(searchParameters, results);
+            
+            var response = new TraineeshipSearchResponse(results.Total, results.Documents, searchParameters);
+
+            return response;
+        }
+        
+        private ISearchResponse<TraineeshipSearchResult> PerformSearch(TraineeshipSearchRequestParameters parameters)
+        {
+            var client = _elasticSearchFactory.GetElasticClient(_config.HostName);
+
+            var result = client.Search<TraineeshipSearchResult>(s =>
+            {
+                s.Index(_config.TraineeshipsIndex);
+                s.Type(ElasticTypes.Traineeship);
+                s.Skip((parameters.PageNumber - 1) * parameters.PageSize);
+                s.Take(parameters.PageSize);
+
+                s.TrackScores();
+
+                s.Query(q =>
+                {
+                    if(string.IsNullOrEmpty(parameters.VacancyReference))
+                        return GetQuery(parameters, q);
+
+                    return q.Filtered(sl =>
+                        sl.Filter(fs =>
+                            fs.Term(f =>
+                                f.VacancyReference, parameters.VacancyReference)));
+                });
+
+                switch (parameters.SortType)
+                {
+                    case VacancySearchSortType.RecentlyAdded:
+
+                        s.Sort(v => v.OnField(f => f.PostedDate).Descending());
+                        s.TrySortByGeoDistance(parameters);
+
+                        break;
+                    case VacancySearchSortType.Distance:
+
+                        s.TrySortByGeoDistance(parameters);
+
+                        break;
+                    case VacancySearchSortType.ClosingDate:
+
+                        s.Sort(v => v.OnField(f => f.ClosingDate).Ascending());
+                        s.TrySortByGeoDistance(parameters);
+                        
+                        break;
+                }
+
+                return s;
+            });
+
+            return result;
+        }
+
+        private QueryContainer GetQuery(TraineeshipSearchRequestParameters parameters, QueryDescriptor<TraineeshipSearchResult> q)
+        {
+            QueryContainer query = null;
+            
+            if (parameters.IsLatLongSearch && parameters.SearchRadius != 0)
+            {
+                var queryClause = q.Filtered(qf => qf.Filter(f => f
+                    .GeoDistance(vs => vs
+                        .Location, descriptor => descriptor
+                            .Location(parameters.Latitude.Value, parameters.Longitude.Value)
+                            .Distance(parameters.SearchRadius, GeoUnit.Miles))));
+                query = query && queryClause;
+            }
+
+            return query;
+        }
+
+        private void SetPostSearchValues(TraineeshipSearchRequestParameters searchParameters, ISearchResponse<TraineeshipSearchResult> results)
+        {
+            foreach (var result in results.Documents)
+            {
+                var hitMd = results.HitsMetaData.Hits.First(h => h.Id == result.Id.ToString(CultureInfo.InvariantCulture));
+
+                if (searchParameters.IsLatLongSearch)
+                {
+                    if (searchParameters.SortType == VacancySearchSortType.ClosingDate ||
+                        searchParameters.SortType == VacancySearchSortType.Distance ||
+                        searchParameters.SortType == VacancySearchSortType.RecentlyAdded)
+                    {
+                        result.Distance = double.Parse(hitMd.Sorts.Skip(hitMd.Sorts.Count() - 1).First().ToString());
+                    }
+                }
+
+                result.Score = hitMd.Score;
+            }
+        }
+    }
+}

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/VacancyServicesSearchConfiguration.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/VacancyServicesSearchConfiguration.cs
@@ -1,0 +1,11 @@
+﻿namespace SFA.DAS.VacancyServices.Search
+{
+    public class VacancyServicesSearchConfiguration
+    {
+        public string HostName { get; set; }
+        public string ApprenticeshipsIndex { get; set; }
+        public string TraineeshipsIndex { get; set; }
+        public string LocationsIndex { get; set; }
+    }
+    
+}


### PR DESCRIPTION
I've create 3 clients for each of the indexes:
- ApprenticeshipSearchClient
- TraineeshipSearchClient
- LocationSearchClient

This is essentially a cut-paste-refactor-simplify of the existing search logic in FAA.

This will initially be consumed by FAA for vacancy searching. It will soon be used by the Vacancy API (and more) so we have consistent searching across the products.

I've also added tests that ensure the passed in search parameters map to the expected JSON posted to Elastic.
