### PR TITLE
RA-2088 downgrades newtonsoft json

### DIFF
--- a/SFA.DAS.Http/SFA.DAS.Http/SFA.DAS.Http.csproj
+++ b/SFA.DAS.Http/SFA.DAS.Http/SFA.DAS.Http.csproj
@@ -18,13 +18,13 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45'">
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.13.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.8" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
   


### PR DESCRIPTION
Downgrading newtonsoft json to version 9.0.1 from version 10.x as the consumer library in FAA cannot be upgraded to version 10.x. 