### PR TITLE
ER-2080 GeoDistance sort without radius

### DIFF
--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/ApprenticeshipSearchClientTests.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/ApprenticeshipSearchClientTests.cs
@@ -249,7 +249,6 @@ namespace SFA.DAS.VacancyServices.Search.UnitTests
                 PageNumber = 1,
                 PageSize = 5,
                 SearchField = ApprenticeshipSearchField.All,
-                SearchRadius = 40,
                 SortType = VacancySearchSortType.ClosingDate,
                 VacancyLocationType = VacancyLocationType.National
             };
@@ -273,6 +272,27 @@ namespace SFA.DAS.VacancyServices.Search.UnitTests
             };
 
             const string expectedJsonQuery = "{\"from\":0,\"size\":5,\"track_scores\":true,\"sort\":[{\"closingDate\":{\"order\":\"asc\"}}],\"query\":{\"bool\":{\"must\":[{\"match\":{\"vacancyLocationType\":{\"query\":\"National\"}}},{\"match\":{\"apprenticeshipLevel\":{\"query\":\"Advanced\"}}}]}}}";
+
+            AssertSearch(parameters, expectedJsonQuery);
+        }
+
+        [Test]
+        public void Search_ShouldIncludeGeoDistanceInSort()
+        {
+            var parameters = new ApprenticeshipSearchRequestParameters
+            {
+                ApprenticeshipLevel = "Higher",
+                Latitude = 52.4088862063274,
+                Longitude = 1.50554768088033,
+                SearchRadius = null,
+                PageNumber = 1,
+                PageSize = 5,
+                SearchField = ApprenticeshipSearchField.All,
+                SortType = VacancySearchSortType.ClosingDate,
+                VacancyLocationType = VacancyLocationType.NonNational
+            };
+
+            const string expectedJsonQuery = "{\"from\":0,\"size\":5,\"track_scores\":true,\"sort\":[{\"closingDate\":{\"order\":\"asc\"}},{\"_geo_distance\":{\"location\":\"52.4088862063274, 1.50554768088033\",\"unit\":\"mi\"}}],\"query\":{\"bool\":{\"must\":[{\"match\":{\"vacancyLocationType\":{\"query\":\"NonNational\"}}},{\"match\":{\"apprenticeshipLevel\":{\"query\":\"Higher\"}}}]}}}";
 
             AssertSearch(parameters, expectedJsonQuery);
         }

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/TraineeshipSearchClientTests.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search.UnitTests/TraineeshipSearchClientTests.cs
@@ -53,6 +53,25 @@ namespace SFA.DAS.VacancyServices.Search.UnitTests
         }
 
         [Test]
+        public void Search_ShouldIncludeGeoDistanceInSort()
+        {
+            var parameters = new TraineeshipSearchRequestParameters
+            {
+                DisabilityConfidentOnly = true,
+                Latitude = 52.4173666904458,
+                Longitude = -1.88983017452229,
+                PageNumber = 1,
+                PageSize = 5,
+                SearchRadius = null,
+                SortType = VacancySearchSortType.RecentlyAdded,
+            };
+
+            const string expectedJsonQuery = "{\"from\":0,\"size\":5,\"track_scores\":true,\"sort\":[{\"postedDate\":{\"order\":\"desc\"}},{\"_geo_distance\":{\"location\":\"52.4173666904458, -1.88983017452229\",\"unit\":\"mi\"}}],\"query\":{\"match\":{\"isDisabilityConfident\":{\"query\":\"True\"}}}}";
+
+            AssertSearch(parameters, expectedJsonQuery);
+        }
+
+        [Test]
         public void Search_ShouldSearchByVacancyReference()
         {
             var parameters = new TraineeshipSearchRequestParameters

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/ApprenticeshipSearchClient.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/ApprenticeshipSearchClient.cs
@@ -201,7 +201,7 @@
                 query &= queryDisabilityConfidentOnly;
             }
 
-            if (parameters.IsLatLongSearch)
+            if (parameters.CanFilterByGeoDistance)
             {
                 var queryClause = q.Filtered(qf => qf.Filter(f => f
                     .GeoDistance(vs => vs
@@ -227,7 +227,7 @@
                     search.TrySortByGeoDistance(parameters);
                     search.SortDescending(r => r.VacancyReference);
 
-                    return parameters.IsLatLongSearch ? 1 : -1;
+                    return parameters.CanSortByGeoDistance ? 1 : -1;
 
                 case VacancySearchSortType.Distance:
 
@@ -235,14 +235,14 @@
                     search.SortDescending(r => r.PostedDate);
                     search.SortDescending(r => r.VacancyReference);
 
-                    return parameters.IsLatLongSearch ? 0 : -1;
+                    return parameters.CanSortByGeoDistance ? 0 : -1;
 
                 case VacancySearchSortType.ClosingDate:
 
                     search.SortAscending(r => r.ClosingDate);
                     search.TrySortByGeoDistance(parameters);
 
-                    return parameters.IsLatLongSearch ? 1 : -1;
+                    return parameters.CanSortByGeoDistance ? 1 : -1;
 
                 case VacancySearchSortType.ExpectedStartDate:
 
@@ -250,13 +250,13 @@
                     search.SortAscending(r => r.VacancyReference);
                     search.TrySortByGeoDistance(parameters);
 
-                    return parameters.IsLatLongSearch ? 2 : -1;
+                    return parameters.CanSortByGeoDistance ? 2 : -1;
                 default:
 
                     search.Sort(sort => sort.OnField("_score").Descending());
                     search.TrySortByGeoDistance(parameters);
 
-                    return parameters.IsLatLongSearch ? 1 : -1;
+                    return parameters.CanSortByGeoDistance ? 1 : -1;
             }
         }
 
@@ -342,7 +342,7 @@
             {
                 var hitMd = results.HitsMetaData.Hits.First(h => h.Id == result.Id.ToString(CultureInfo.InvariantCulture));
 
-                if(searchParameters.IsLatLongSearch)
+                if(searchParameters.CanSortByGeoDistance)
                     result.Distance = (double)hitMd.Sorts.ElementAt(geoDistanceSortPosition);
 
                 result.Score = hitMd.Score;

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Extensions/SearchDescriptorExtensions.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Extensions/SearchDescriptorExtensions.cs
@@ -9,7 +9,7 @@ namespace SFA.DAS.VacancyServices.Search
     {
         internal static SearchDescriptor<ApprenticeshipSearchResult> TrySortByGeoDistance(this SearchDescriptor<ApprenticeshipSearchResult> searchDescriptor, ApprenticeshipSearchRequestParameters searchParameters)
         {
-            if (searchParameters.IsLatLongSearch)
+            if (searchParameters.CanSortByGeoDistance)
             {
                 searchDescriptor.SortGeoDistance(g =>
                 {
@@ -24,7 +24,7 @@ namespace SFA.DAS.VacancyServices.Search
 
         internal static SearchDescriptor<TraineeshipSearchResult> TrySortByGeoDistance(this SearchDescriptor<TraineeshipSearchResult> searchDescriptor, TraineeshipSearchRequestParameters searchParameters)
         {
-            if (searchParameters.IsLatLongSearch)
+            if (searchParameters.CanSortByGeoDistance)
             {
                 searchDescriptor.SortGeoDistance(g =>
                 {

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Requests/ApprenticeshipSearchRequestParameters.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Requests/ApprenticeshipSearchRequestParameters.cs
@@ -26,6 +26,8 @@ namespace SFA.DAS.VacancyServices.Search.Requests
         public VacancyLocationType VacancyLocationType { get; set; }
         public string VacancyReference { get; set; }
 
-        public bool IsLatLongSearch => Latitude.HasValue && Longitude.HasValue && SearchRadius.HasValue;
+        public bool CanFilterByGeoDistance => Latitude.HasValue && Longitude.HasValue && SearchRadius.HasValue;
+
+        public bool CanSortByGeoDistance => Latitude.HasValue && Longitude.HasValue;
     }
 }

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Requests/TraineeshipSearchRequestParameters.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/Requests/TraineeshipSearchRequestParameters.cs
@@ -11,6 +11,8 @@
         public VacancySearchSortType SortType { get; set; }
         public string VacancyReference { get; set; }
 
-        public bool IsLatLongSearch => Latitude.HasValue && Longitude.HasValue && SearchRadius.HasValue;
+        public bool CanFilterByGeoDistance => Latitude.HasValue && Longitude.HasValue && SearchRadius.HasValue;
+
+        public bool CanSortByGeoDistance => Latitude.HasValue && Longitude.HasValue;
     }
 }

--- a/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/TraineeshipSearchClient.cs
+++ b/SFA.DAS.VacancyServices.Search/SFA.DAS.VacancyServices.Search/TraineeshipSearchClient.cs
@@ -116,7 +116,7 @@
                 query &= queryDisabilityConfidentOnly;
             }
 
-            if (parameters.IsLatLongSearch)
+            if (parameters.CanFilterByGeoDistance)
             {
                 var queryClause = q.Filtered(qf => qf.Filter(f => f
                     .GeoDistance(vs => vs
@@ -140,27 +140,27 @@
                     search.SortDescending(r => r.PostedDate);
                     search.TrySortByGeoDistance(parameters);
 
-                    return parameters.IsLatLongSearch ? 1 : -1;
+                    return parameters.CanSortByGeoDistance ? 1 : -1;
 
                 case VacancySearchSortType.Distance:
 
                     search.TrySortByGeoDistance(parameters);
 
-                    return parameters.IsLatLongSearch ? 0 : -1;
+                    return parameters.CanSortByGeoDistance ? 0 : -1;
 
                 case VacancySearchSortType.ClosingDate:
 
                     search.SortAscending(r => r.ClosingDate);
                     search.TrySortByGeoDistance(parameters);
 
-                    return parameters.IsLatLongSearch ? 1 : -1;
+                    return parameters.CanSortByGeoDistance ? 1 : -1;
 
                 default:
 
                     search.Sort(sort => sort.OnField("_score").Descending());
                     search.TrySortByGeoDistance(parameters);
 
-                    return parameters.IsLatLongSearch ? 1 : -1;
+                    return parameters.CanSortByGeoDistance ? 1 : -1;
             }
         }
 
@@ -170,7 +170,7 @@
             {
                 var hitMd = results.HitsMetaData.Hits.First(h => h.Id == result.Id.ToString(CultureInfo.InvariantCulture));
 
-                if (searchParameters.IsLatLongSearch)
+                if (searchParameters.CanSortByGeoDistance)
                     result.Distance = (double)hitMd.Sorts.ElementAt(geoDistanceSortPosition);
 
                 result.Score = hitMd.Score;


### PR DESCRIPTION
In FAA if you select 'England' as the radius then no SearchRadius is specified so we do not filter by lat/long.   This meant the 'distance' being returned in the results was 0.

The lat/long is passed into the search though so we can still Sort by GeoDistance even if we can't Filter on it.  So this ticket allows us to do this and return the distance in the search results.