### PR TITLE
ER-1020 - Added IsAnonymous

### DIFF
--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/Vacancy.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Entities/Vacancy.cs
@@ -22,6 +22,7 @@ namespace SFA.DAS.Recruit.Vacancies.Client.Entities
         public Address EmployerLocation { get; set; }
         public string EmployerName { get; set; }
         public string EmployerWebsiteUrl { get; set; }
+        public bool IsAnonymous { get; set; }
         public DateTime LiveDate { get; set; }
         public int NumberOfPositions { get; set; }
         public string OutcomeDescription { get; set; }


### PR DESCRIPTION
There is behaviour in FAA that needs to know whether the vacancy is anonymous or not.

There are a couple of ways we can do this. I can infer that the vacancy is anonymous by looking at the address of the projected vacancy and if address line 1-4 are empty and the postcode is an outcode then I can assume the vacancy is anonymons.....This feels hacky so I think explicitly adding a new 'anonymous' field to the projection is the correct thing to do.

Initially I was contemplating exposing `EmployerNameOption` in the vacancy projection. But this enum  feels like an internal thing that doesn't make much sense outside of the v2 applications.

So I think just adding a bool `IsAnonymous` to the projection and its set by `EmployerNameOption == Anonymous`.

What do you think?