### PR TITLE
FC-472 Employer Menu

### DIFF
--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/.vscode/tasks.json
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet build",
+            "type": "shell",
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Configuration/MaMenuConfiguration.cs
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Configuration/MaMenuConfiguration.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace SFA.DAS.Employer.Shared.UI.Configuration
+{
+    public class MaMenuConfiguration
+    {
+        public SiteConfiguration Ma { get; set; }
+        public SiteConfiguration Commitments { get; set; }
+        public SiteConfiguration Recruit { get; set; }
+        public SiteConfiguration Identity { get; set; }
+        public string LocalLogoutRouteName { get; set; }
+        public string IdentityClientIdConfigKey { get; set; }
+        public string ClientId { get; internal set; }
+    }
+
+
+}

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Configuration/SiteConfiguration.cs
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Configuration/SiteConfiguration.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace SFA.DAS.Employer.Shared.UI.Configuration
+{
+    public class SiteConfiguration
+    {
+        public string RootUrl { get; set; }
+        public Dictionary<string, string> Routes { get; set; }
+    }
+}

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/README.md
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/README.md
@@ -9,5 +9,83 @@ This project provides shared Employer site UI components via a [Razor Class Libr
 - Footer
 - Menu
 
-TODO: Describe usage
+## Usage
 
+Add the package to the web project and add the following into the *ConfigureServices* method:
+
+```csharp
+private IConfiguration _configuration;
+
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddMaMenuConfiguration(_configuration, "Logout_Route", "idamsClientId");
+}
+```
+Where in the above example *Logout_Route* is the Route Name of the action used to sign the user out of the site and *idamsClientId* is the Employer Idams Relying Party ClientId.
+
+
+The components can be added into the web apps' Razor views by adding the partial views that the RCL contains e.g.
+
+```html
+<partial name="_Header">
+<partial name="_Menu" model="@accountId">
+<partial name="_Footer">
+```
+
+**Note**: the *Menu* parital view requires an *accountId* (the hashed account id used in the url) to enable it to generate the menu links.
+
+### Configuration
+The RCL library uses `IConfiguration` as it's source for items such as the urls of the other employer sites and paths within those site that links are generated for. 
+
+The idea is that there is a shared configuration location that all the Employer apps can share (Azure Table Storage) which they'd all consume. However this is not essential as long as the web app includes the matching configuration values expected.
+
+Here is the configuration structure that is expected by the component:
+```json
+"MaPageConfiguration": {
+    "Ma": {
+      "RootUrl": "https://das-test-accui-as.azurewebsites.net",
+      "Routes": {
+        "AccountsHome": "/accounts/{0}/teams",
+        "Help": "/service/help",
+        "Privacy": "/service/privacy",
+        "Accounts": "/service/accounts",
+        "RenameAccount": "/accounts/{0}/rename",
+        "Notifications": "/settings/notifications",
+        "AccountsFinance": "/accounts/{0}/finance",
+        "AccountsTeamsView": "/accounts/{0}/teams/view",
+        "AccountsAgreements": "/accounts/{0}/agreements",
+        "AccountsSchemes": "/accounts/{0}/schemes"
+      }
+    },
+    "Commitments": {
+      "RootUrl": "https://test-empc.apprenticeships.sfa.bis.gov.uk",
+      "Routes": {
+        "ApprenticesHome": "/commitments/accounts/{0}/apprentices/home"
+      }
+    },
+    "Recruit": {
+      "RootUrl": "https://recruit.test-eas.apprenticeships.sfa.bis.gov.uk",
+      "Routes": {
+        "RecruitHome": "/accounts/{0}"
+      }
+    },
+    "Identity": {
+      "RootUrl": "https://test-login.apprenticeships.sfa.bis.gov.uk",
+      "Routes": {
+        "ChangePassword": "/account/changepassword?clientId={0}&returnUrl={1}",
+        "ChangeEmailAddress": "/account/changeemail?clientId={0}&returnUrl={1}"
+      }
+    }
+  }
+```
+### Menu Behaviour
+There are scenarios where the menu needs to display differently. There are 2 additional *modes* that are supported. These modes are currenly controlled by *ViewBag* boolean values. 
+
+| ViewBag property | Description                                                |
+| ---------------- |:----------------------------------------------------------:|
+| IsErrorPage      | Hides *Rename Account* & *Notfications* items              |
+| ShowNav          | Hides the top level menu (Doesn't include *settings*)      |
+
+
+### Override Partial Views
+Any of the parital views that are defined in the RCL can be overriden in the consuming application simply by defining a partial view with the same name ane location e.g. */Views/Shared/_Header.cshtl*

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/README.md
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/README.md
@@ -1,0 +1,13 @@
+
+
+SFA.DAS.Employer.Shared.UI
+==========
+
+This project provides shared Employer site UI components via a [Razor Class Library](https://docs.microsoft.com/en-us/aspnet/core/razor-pages/ui-class?view=aspnetcore-2.2&tabs=visual-studio). It currently consists of the following:
+
+- Header
+- Footer
+- Menu
+
+TODO: Describe usage
+

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/README.md
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/README.md
@@ -35,13 +35,14 @@ The components can be added into the web apps' Razor views by adding the partial
 **Note**: the *Menu* parital view requires an *accountId* (the hashed account id used in the url) to enable it to generate the menu links.
 
 ### Configuration
-The RCL library uses `IConfiguration` as it's source for items such as the urls of the other employer sites and paths within those site that links are generated for. 
+The RCL library uses `IConfiguration` as it's source for items such as the urls of the other employer sites and paths within those sites which are used to generate the menu links. 
 
-The idea is that there is a shared configuration location that all the Employer apps can share (Azure Table Storage) which they'd all consume. However this is not essential as long as the web app includes the matching configuration values expected.
+Azure Table Storage (`SFA.DAS.Employer.Menu`) will provide a shared configuration location that all apps should use. You can use the [SFA.DAS.Configuration.AzureTableStorage](https://www.nuget.org/packages/SFA.DAS.Configuration.AzureTableStorage/)  package for consuming the shared conifguration. 
 
-Here is the configuration structure that is expected by the component:
+Here is the configuration structure that is expected by the component when using Azure Table Storage:
 ```json
-"MaPageConfiguration": {
+{
+  "MaPageConfiguration": {
     "Ma": {
       "RootUrl": "https://das-test-accui-as.azurewebsites.net",
       "Routes": {
@@ -77,6 +78,7 @@ Here is the configuration structure that is expected by the component:
       }
     }
   }
+}
 ```
 ### Menu Behaviour
 There are scenarios where the menu needs to display differently. There are 2 additional *modes* that are supported. These modes are currenly controlled by *ViewBag* boolean values. 

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI.csproj
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>SFA.DAS.Employer.Shared.UI</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
+    <PackageVersion>1.0.1</PackageVersion>
     <Authors>GOV.UK Education and Skills Funding Agency (ESFA) Digital Apprenticeship Service (DAS)</Authors>
     <Description>Shared library containing shared Employer UI components.</Description>
     <License>https://github.com/SkillsFundingAgency/das-shared-packages/blob/master/LICENSE</License>

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI.csproj
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>SFA.DAS.Employer.Shared.UI</RootNamespace>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <Authors>GOV.UK Education and Skills Funding Agency (ESFA) Digital Apprenticeship Service (DAS)</Authors>
+    <Description>Shared library containing shared Employer UI components.</Description>
+    <License>https://github.com/SkillsFundingAgency/das-shared-packages/blob/master/LICENSE</License>
+    <PackageProjectUrl>https://github.com/SkillsFundingAgency/das-shared-packages</PackageProjectUrl>
+
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1"/>
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1"/>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1"/>
+  </ItemGroup>
+</Project>

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI.csproj
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>SFA.DAS.Employer.Shared.UI</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Authors>GOV.UK Education and Skills Funding Agency (ESFA) Digital Apprenticeship Service (DAS)</Authors>
     <Description>Shared library containing shared Employer UI components.</Description>
     <License>https://github.com/SkillsFundingAgency/das-shared-packages/blob/master/LICENSE</License>

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI.csproj
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>SFA.DAS.Employer.Shared.UI</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <PackageVersion>1.0.1</PackageVersion>
+    <Version>1.0.3</Version>
     <Authors>GOV.UK Education and Skills Funding Agency (ESFA) Digital Apprenticeship Service (DAS)</Authors>
     <Description>Shared library containing shared Employer UI components.</Description>
     <License>https://github.com/SkillsFundingAgency/das-shared-packages/blob/master/LICENSE</License>

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/ServiceCollectionExtensions.cs
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/ServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SFA.DAS.Employer.Shared.UI.Configuration;
+
+namespace SFA.DAS.Employer.Shared.UI
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void AddMaMenuConfiguration(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.Configure<MaMenuConfiguration>(configuration.GetSection("MaPageConfiguration"));
+            services.PostConfigure<MaMenuConfiguration>(options =>
+            {
+                options.ClientId = configuration.GetValue<string>(options.IdentityClientIdConfigKey);
+            });
+        }
+    }
+}

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/ServiceCollectionExtensions.cs
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.Employer.Shared.UI
             ValidateArguments(logoutRouteName, identityClientId);
             
             // TODO: Validate configuration values?
-            services.Configure<MaMenuConfiguration>(configuration.GetSection("SFA.DAS.Employer.Menu:MaPageConfiguration"));
+            services.Configure<MaMenuConfiguration>(configuration.GetSection("SFA.DAS.Employer.Shared.UI:MaPageConfiguration"));
             services.PostConfigure<MaMenuConfiguration>(options =>
             {
                 options.ClientId = identityClientId;

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/ServiceCollectionExtensions.cs
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using SFA.DAS.Employer.Shared.UI.Configuration;
@@ -6,13 +7,30 @@ namespace SFA.DAS.Employer.Shared.UI
 {
     public static class ServiceCollectionExtensions
     {
-        public static void AddMaMenuConfiguration(this IServiceCollection services, IConfiguration configuration)
+        public static void AddMaMenuConfiguration(this IServiceCollection services, IConfiguration configuration, string logoutRouteName, string identityClientId)
         {
+            ValidateArguments(logoutRouteName, identityClientId);
+            
+            // TODO: Validate configuration values?
             services.Configure<MaMenuConfiguration>(configuration.GetSection("MaPageConfiguration"));
             services.PostConfigure<MaMenuConfiguration>(options =>
             {
-                options.ClientId = configuration.GetValue<string>(options.IdentityClientIdConfigKey);
+                options.ClientId = identityClientId;
+                options.LocalLogoutRouteName = logoutRouteName;
             });
+        }
+
+        private static void ValidateArguments(string logoutRouteName, string identityClientId)
+        {
+            if (string.IsNullOrWhiteSpace(logoutRouteName))
+            {
+                throw new ArgumentException("Needs a valid value", nameof(logoutRouteName));
+            }
+
+            if (string.IsNullOrWhiteSpace(identityClientId))
+            {
+                throw new ArgumentException("Needs a valid value", nameof(identityClientId));
+            }
         }
     }
 }

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/ServiceCollectionExtensions.cs
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.Employer.Shared.UI
             ValidateArguments(logoutRouteName, identityClientId);
             
             // TODO: Validate configuration values?
-            services.Configure<MaMenuConfiguration>(configuration.GetSection("MaPageConfiguration"));
+            services.Configure<MaMenuConfiguration>(configuration.GetSection("SFA.DAS.Employer.Menu:MaPageConfiguration"));
             services.PostConfigure<MaMenuConfiguration>(options =>
             {
                 options.ClientId = identityClientId;

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/UrlBuilder.cs
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/UrlBuilder.cs
@@ -1,0 +1,7 @@
+namespace SFA.DAS.Employer.Shared.UI
+{
+    internal static class UrlBuilder
+    {
+        
+    }
+}

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/UrlBuilder.cs
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/UrlBuilder.cs
@@ -1,7 +1,22 @@
+using SFA.DAS.Employer.Shared.UI.Configuration;
+
 namespace SFA.DAS.Employer.Shared.UI
 {
-    internal static class UrlBuilder
+    public static class UrlBuilder
     {
-        
+        public static string GetLink(SiteConfiguration config, string routeName = null)
+        {
+            return string.IsNullOrWhiteSpace(routeName) ? config.RootUrl : config.RootUrl + config.Routes[routeName];
+        }
+
+        public static string GetLink(SiteConfiguration config, string routeName, string accountId)
+        {
+            return string.Format(config.RootUrl + config.Routes[routeName], accountId);
+        }
+
+        public static string GetLink(SiteConfiguration config, string routeName, string clientId, string returnUrl)
+        {
+            return string.Format(config.RootUrl + config.Routes[routeName], clientId, returnUrl);
+        }
     }
 }

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Footer.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Footer.cshtml
@@ -1,17 +1,12 @@
 @using Microsoft.Extensions.Options
 @using SFA.DAS.Employer.Shared.UI
+@using static SFA.DAS.Employer.Shared.UI.UrlBuilder;
 @inject IOptionsMonitor<MaMenuConfiguration> OptionsAccessor
 
 @{
     var externalLinks = OptionsAccessor.CurrentValue.Ma;
 }
 
-@functions {
-    public string GetLink(string routeName, SiteConfiguration config)
-    {
-        return string.IsNullOrWhiteSpace(routeName) ? config.RootUrl : config.RootUrl + config.Routes[routeName];
-    }
-}
 <footer class="govuk-footer " role="contentinfo">
     <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
@@ -19,13 +14,13 @@
                 <h2 class="govuk-visually-hidden">Support links</h2>
                 <ul class="govuk-footer__inline-list">
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="@GetLink("Help", externalLinks)">Help</a>
+                        <a class="govuk-footer__link" href="@GetLink(externalLinks, "Help")">Help</a>
                     </li>
                     <li class="govuk-footer__inline-list-item">
                         <a class="govuk-footer__link" href="https://www.surveymonkey.co.uk/r/2JPLQ9T" target="_blank">Feedback</a>
                     </li>
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="@GetLink("Privacy", externalLinks)">Privacy and cookies</a>
+                        <a class="govuk-footer__link" href="@GetLink(externalLinks, "Privacy")">Privacy and cookies</a>
                     </li>
                     <li class="govuk-footer__inline-list-item">
                         Built by the <a href="http://gov.uk/sfa" target="_blank" class="govuk-footer__link">Education and Skills Funding Agency</a>

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Footer.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Footer.cshtml
@@ -1,0 +1,47 @@
+@using Microsoft.Extensions.Options
+@using SFA.DAS.Employer.Shared.UI
+@inject IOptionsMonitor<MaMenuConfiguration> OptionsAccessor
+
+@{
+    var externalLinks = OptionsAccessor.CurrentValue.Ma;
+}
+
+@functions {
+    public string GetLink(string routeName, SiteConfiguration config)
+    {
+        return string.IsNullOrWhiteSpace(routeName) ? config.RootUrl : config.RootUrl + config.Routes[routeName];
+    }
+}
+<footer class="govuk-footer " role="contentinfo">
+    <div class="govuk-width-container ">
+        <div class="govuk-footer__meta">
+            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+                <h2 class="govuk-visually-hidden">Support links</h2>
+                <ul class="govuk-footer__inline-list">
+                    <li class="govuk-footer__inline-list-item">
+                        <a class="govuk-footer__link" href="@GetLink("Help", externalLinks)">Help</a>
+                    </li>
+                    <li class="govuk-footer__inline-list-item">
+                        <a class="govuk-footer__link" href="https://www.surveymonkey.co.uk/r/2JPLQ9T" target="_blank">Feedback</a>
+                    </li>
+                    <li class="govuk-footer__inline-list-item">
+                        <a class="govuk-footer__link" href="@GetLink("Privacy", externalLinks)">Privacy and cookies</a>
+                    </li>
+                    <li class="govuk-footer__inline-list-item">
+                        Built by the <a href="http://gov.uk/sfa" target="_blank" class="govuk-footer__link">Education and Skills Funding Agency</a>
+                    </li>
+                </ul>
+                <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+                    <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+                </svg>
+                <span class="govuk-footer__licence-description">
+                    All content is available under the
+                    <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+                </span>
+            </div>
+            <div class="govuk-footer__meta-item">
+                <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Header.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Header.cshtml
@@ -7,9 +7,20 @@
     var externalLinks = OptionsAccessor.CurrentValue.Ma;
 }
 
-<header class="govuk-header " role="banner" data-module="header">
-    <div class="govuk-header__container govuk-width-container">
+@functions {
 
+    private bool ParseHideHeaderBorder()
+    {
+        if (ViewBag.HideHeaderBorder is bool)
+        {
+            return ViewBag.HideHeaderBorder;
+        }
+        return false;
+    }
+}
+
+<header class="govuk-header @(ParseHideHeaderBorder() ? "das-header--no-border" : " ")" role="banner" data-module="header">
+    <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
             <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" class="govuk-header__link govuk-header__link--homepage">
                 <span class="govuk-header__logotype">

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Header.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Header.cshtml
@@ -1,16 +1,10 @@
 @using Microsoft.Extensions.Options
 @using SFA.DAS.Employer.Shared.UI
+@using static SFA.DAS.Employer.Shared.UI.UrlBuilder;
 @inject IOptionsMonitor<MaMenuConfiguration> OptionsAccessor
 
 @{
     var externalLinks = OptionsAccessor.CurrentValue.Ma;
-}
-
-@functions {
-    public string GetLink(string routeName, SiteConfiguration config)
-    {
-        return string.IsNullOrWhiteSpace(routeName) ? config.RootUrl : config.RootUrl + config.Routes[routeName];
-    }
 }
 
 <header class="govuk-header " role="banner" data-module="header">
@@ -31,7 +25,7 @@
             </a>
         </div>
         <div class="govuk-header__content">
-            <a href="@GetLink("", externalLinks)" class="govuk-header__link govuk-header__link--service-name">
+            <a href="@GetLink(externalLinks, "")" class="govuk-header__link govuk-header__link--service-name">
             Manage apprenticeships
             </a>
         </div>

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Header.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Header.cshtml
@@ -1,0 +1,39 @@
+@using Microsoft.Extensions.Options
+@using SFA.DAS.Employer.Shared.UI
+@inject IOptionsMonitor<MaMenuConfiguration> OptionsAccessor
+
+@{
+    var externalLinks = OptionsAccessor.CurrentValue.Ma;
+}
+
+@functions {
+    public string GetLink(string routeName, SiteConfiguration config)
+    {
+        return string.IsNullOrWhiteSpace(routeName) ? config.RootUrl : config.RootUrl + config.Routes[routeName];
+    }
+}
+
+<header class="govuk-header " role="banner" data-module="header">
+    <div class="govuk-header__container govuk-width-container">
+
+        <div class="govuk-header__logo">
+            <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" class="govuk-header__link govuk-header__link--homepage">
+                <span class="govuk-header__logotype">
+
+                    <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
+                        <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                        <image src="/lib/govuk-frontend/dist/assets/images/govuk-logotype-crown.png" class="govuk-header__logotype-crown-fallback-image"></image>
+                    </svg>
+                    <span class="govuk-header__logotype-text">
+                    GOV.UK
+                    </span>
+                </span>
+            </a>
+        </div>
+        <div class="govuk-header__content">
+            <a href="@GetLink("", externalLinks)" class="govuk-header__link govuk-header__link--service-name">
+            Manage apprenticeships
+            </a>
+        </div>
+    </div>
+</header>

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Menu.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Menu.cshtml
@@ -56,58 +56,77 @@
     }
 }
 
-<div id="floating-menu-holder">
-    <div class="account-information floating-menu" role="navigation">
-        <div class="js-float">
-            <p class="floating-head-text">Your employer account</p>
-            <nav id="user-nav">
-                <ul role="menubar">
-                    <li><a href='@GetLink(externalLinks.Ma, "Help")' class="menu-main">Help</a></li>
-                    @if (Context.User.Identity.IsAuthenticated)
-                    {
-                        <li class="has-sub-menu">
-                            <a href="/" role="menuitem" class="menu-main">Settings</a>
-                            <ul role="menu" id="settings-menu" class="js-hidden">
-                                <li><a href='@GetLink(externalLinks.Ma, "Accounts", accountId)' role="menuitem" class="sub-menu-item">Your accounts</a></li>
-                                @if(!IsErrorPage()) 
-                                {
-                                    <li><a href='@GetLink(externalLinks.Ma, "RenameAccount", accountId)' class="sub-menu-item">Rename account</a></li>
-                                }
-                                <li><a href='@GetLink(externalLinks.Identity, "ChangePassword", clientId, GetEncodedReturnUrl(Context.Request))' class="sub-menu-item">Change your password</a></li>
-                                <li><a href='@GetLink(externalLinks.Identity, "ChangeEmailAddress", clientId, GetEncodedReturnUrl(Context.Request))' class="sub-menu-item">Change your email address</a></li>
-                                @if(!IsErrorPage()) 
-                                {
-                                    <li><a href='@GetLink(externalLinks.Ma, "Notifications")' class="sub-menu-item">Notifications settings</a></li>
-                                }
-                            </ul>
-                        </li>
-                        <li><a asp-route="@externalLinks.LocalLogoutRouteName" role="menuitem" class="menu-main">Sign out</a></li>
-                    }
-                    else
-                    {
-                        <li><a href="@GetLink(externalLinks.Ma)" role="menuitem">Sign in / Register</a></li>
-                    }
-                </ul>
-            </nav>
-        </div>
+<div class="das-account-header das-account-header--employer">
+    <div class="govuk-width-container">
+        <p class="das-account-header__title">Your employer account</p>
+        <nav class="das-user-navigation" id="user-nav">
+            <ul class="das-user-navigation__list" role="menu">
+                <li role="menuitem" class="das-user-navigation__list-item">
+                    <a href='@GetLink(externalLinks.Ma, "Help")' class="das-user-navigation__link">Help</a>
+                </li>
+                @if (Context.User.Identity.IsAuthenticated)
+                {
+                    <li class="has-sub-menu">
+                        <a href="/" role="menuitem" class="das-user-navigation__link">Settings</a>
+                        <ul role="menu" id="settings-menu" class="js-hidden">
+                            <li><a href='@GetLink(externalLinks.Ma, "Accounts", accountId)' role="menuitem" class="sub-menu-item">Your accounts</a></li>
+                            @if(!IsErrorPage())
+                            {
+                                <li><a href='@GetLink(externalLinks.Ma, "RenameAccount", accountId)' class="sub-menu-item">Rename account</a></li>
+                            }
+                            <li><a href='@GetLink(externalLinks.Identity, "ChangePassword", clientId, GetEncodedReturnUrl(Context.Request))' class="sub-menu-item">Change your password</a></li>
+                            <li><a href='@GetLink(externalLinks.Identity, "ChangeEmailAddress", clientId, GetEncodedReturnUrl(Context.Request))' class="sub-menu-item">Change your email address</a></li>
+                            @if(!IsErrorPage())
+                            {
+                                <li><a href='@GetLink(externalLinks.Ma, "Notifications")' class="sub-menu-item">Notifications settings</a></li>
+                            }
+                        </ul>
+                    </li>
+                    <li role="menuitem" class="das-user-navigation__list-item">
+                        <a asp-route="@externalLinks.LocalLogoutRouteName" role="menuitem" class="das-user-navigation__link">Sign out</a>
+                    </li>
+                }
+                else
+                {
+                    <li role="menuitem" class="das-user-navigation__list-item">
+                        <a href="@GetLink(externalLinks.Ma)" role="menuitem" class="das-user-navigation__link">Sign in / Register</a>
+                    </li>
+                }
+            </ul>
+        </nav>
     </div>
-</div> <!--/floating-menu-holder-->
+</div>
+
 @if (Context.User.Identity.IsAuthenticated)
 {
     if(ParseHideNavFromViewBag())
     {
-        <div class="header-organisation" role="navigation">
-            <nav class="header-inner">
-                <ul role="menubar" id="global-nav-links">
-                    <li><a href='@GetLink(externalLinks.Ma, "AccountsHome", accountId)' role="menuitem">Home</a></li>
-                    <li><a href='@GetLink(externalLinks.Ma, "AccountsFinance", accountId)' role="menuitem">Finance</a></li>
-                    <li><a href='@GetLink(externalLinks.Recruit, "RecruitHome", accountId)' class="selected" role="menuitem">Recruitment</a></li>
-                    <li><a href='@GetLink(externalLinks.Commitments, "ApprenticesHome", accountId)' role="menuitem">Apprentices</a></li>
-                    <li><a href='@GetLink(externalLinks.Ma, "AccountsTeamsView", accountId)' role="menuitem">Your team</a></li>
-                    <li><a href='@GetLink(externalLinks.Ma, "AccountsAgreements", accountId)' role="menuitem">Your organisations and agreements</a></li>
-                    <li><a href='@GetLink(externalLinks.Ma, "AccountsSchemes", accountId)' role="menuitem">PAYE schemes</a></li>
-                </ul>
-            </nav>
-        </div>
+        <nav class="das-navigation">
+            <div class="govuk-width-container">
+                <ul class="das-navigation__list" id="navigation" role="menu">
+                    <li class="das-navigation__list-item">
+                        <a class="das-navigation__link" href='@GetLink(externalLinks.Ma, "AccountsHome", accountId)'>Home</a>
+                    </li>
+                    <li class="das-navigation__list-item">
+                        <a class="das-navigation__link" href='@GetLink(externalLinks.Ma, "AccountsFinance", accountId)'>Finance</a>
+                    </li>
+                    <li class="das-navigation__list-item">
+                        <a class="das-navigation__link" href='@GetLink(externalLinks.Recruit, "RecruitHome", accountId)'>Recruitment</a>
+                    </li>
+                    <li class="das-navigation__list-item">
+                        <a class="das-navigation__link" href='@GetLink(externalLinks.Commitments, "ApprenticesHome", accountId)'>Apprentices</a>
+                    </li>
+                    <li class="das-navigation__list-item">
+                        <a class="das-navigation__link" href='@GetLink(externalLinks.Ma, "AccountsTeamsView", accountId)'>Your team</a>
+                    </li>
+                    <li class="das-navigation__list-item">
+                        <a class="das-navigation__link" href='@GetLink(externalLinks.Ma, "AccountsAgreements", accountId)'>Your organisations and agreements</a>
+                    </li>
+                    <li class="das-navigation__list-item">
+                        <a class="das-navigation__link" href='@GetLink(externalLinks.Ma, "AccountsSchemes", accountId)'>PAYE schemes</a>
+                    </li>
+                 </ul>
+             </div>
+         </nav>
     }
 }

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Menu.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Menu.cshtml
@@ -1,0 +1,113 @@
+@model string
+@using Microsoft.Extensions.Options
+@using SFA.DAS.Employer.Shared.UI
+@using Microsoft.AspNetCore.Http
+@using System.Net
+@inject IOptionsMonitor<MaMenuConfiguration> OptionsAccessor
+
+@{
+    var accountId = Model;
+    var clientId = OptionsAccessor.CurrentValue.ClientId;
+    var externalLinks = OptionsAccessor.CurrentValue;
+}
+
+@functions {
+    private static string GetLink(SiteConfiguration config, string routeName = null)
+    {
+        return string.IsNullOrWhiteSpace(routeName) ? config.RootUrl : config.RootUrl + config.Routes[routeName];
+    }
+
+    private static string GetLink(SiteConfiguration config, string routeName, string accountId)
+    {
+        return string.Format(config.RootUrl + config.Routes[routeName], accountId);
+    }
+
+    private static string GetLink(SiteConfiguration config, string routeName, string clientId, string returnUrl)
+    {
+        return string.Format(config.RootUrl + config.Routes[routeName], clientId, returnUrl);
+    }
+
+    private bool IsErrorPage()
+    {
+        if (ViewBag.IsErrorPage is bool)
+        {
+            return ViewBag.IsErrorPage;
+        }
+
+        return false;
+    }
+
+    private bool ParseHideNavFromViewBag()
+    {
+        if (ViewBag.ShowNav is bool)
+        {
+            return ViewBag.ShowNav;
+        }
+
+        return true;
+    }
+
+    private static string GetEncodedReturnUrl(HttpRequest request)
+    {
+        var url = $"{request.Scheme}://{request.Host}";
+        var encodedReturnUrl = WebUtility.UrlEncode($"{url}{request.Path}");    
+
+        return encodedReturnUrl;
+    }
+}
+
+<div id="floating-menu-holder">
+    <div class="account-information floating-menu" role="navigation">
+        <div class="js-float">
+            <p class="floating-head-text">Your employer account</p>
+            <nav id="user-nav">
+                <ul role="menubar">
+                    <li><a href='@GetLink(externalLinks.Ma, "Help")' class="menu-main">Help</a></li>
+                    @if (Context.User.Identity.IsAuthenticated)
+                    {
+                        <li class="has-sub-menu">
+                            <a href="/" role="menuitem" class="menu-main">Settings</a>
+                            <ul role="menu" id="settings-menu" class="js-hidden">
+                                <li><a href='@GetLink(externalLinks.Ma, "Accounts", accountId)' role="menuitem" class="sub-menu-item">Your accounts</a></li>
+                                @if(!IsErrorPage()) 
+                                {
+                                    <li><a href='@GetLink(externalLinks.Ma, "RenameAccount", accountId)' class="sub-menu-item">Rename account</a></li>
+                                }
+                                <li><a href='@GetLink(externalLinks.Identity, "ChangePassword", clientId, GetEncodedReturnUrl(Context.Request))' class="sub-menu-item">Change your password</a></li>
+                                <li><a href='@GetLink(externalLinks.Identity, "ChangeEmailAddress", clientId, GetEncodedReturnUrl(Context.Request))' class="sub-menu-item">Change your email address</a></li>
+                                @if(!IsErrorPage()) 
+                                {
+                                    <li><a href='@GetLink(externalLinks.Ma, "Notifications")' class="sub-menu-item">Notifications settings</a></li>
+                                }
+                            </ul>
+                        </li>
+                        <li><a asp-route="@externalLinks.LocalLogoutRouteName" role="menuitem" class="menu-main">Sign out</a></li>
+                    }
+                    else
+                    {
+                        <li><a href="@GetLink(externalLinks.Ma)" role="menuitem">Sign in / Register</a></li>
+                    }
+                </ul>
+            </nav>
+        </div>
+    </div>
+</div> <!--/floating-menu-holder-->
+@if (Context.User.Identity.IsAuthenticated)
+{
+    if(ParseHideNavFromViewBag())
+    {
+        <div class="header-organisation" role="navigation">
+            <nav class="header-inner">
+                <ul role="menubar" id="global-nav-links">
+                    <li><a href='@GetLink(externalLinks.Ma, "AccountsHome", accountId)' role="menuitem">Home</a></li>
+                    <li><a href='@GetLink(externalLinks.Ma, "AccountsFinance", accountId)' role="menuitem">Finance</a></li>
+                    <li><a href='@GetLink(externalLinks.Recruit, "RecruitHome", accountId)' class="selected" role="menuitem">Recruitment</a></li>
+                    <li><a href='@GetLink(externalLinks.Commitments, "ApprenticesHome", accountId)' role="menuitem">Apprentices</a></li>
+                    <li><a href='@GetLink(externalLinks.Ma, "AccountsTeamsView", accountId)' role="menuitem">Your team</a></li>
+                    <li><a href='@GetLink(externalLinks.Ma, "AccountsAgreements", accountId)' role="menuitem">Your organisations and agreements</a></li>
+                    <li><a href='@GetLink(externalLinks.Ma, "AccountsSchemes", accountId)' role="menuitem">PAYE schemes</a></li>
+                </ul>
+            </nav>
+        </div>
+    }
+}

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Menu.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Menu.cshtml
@@ -1,8 +1,8 @@
 @model string
 @using Microsoft.Extensions.Options
-@using SFA.DAS.Employer.Shared.UI
 @using Microsoft.AspNetCore.Http
 @using System.Net
+@using static SFA.DAS.Employer.Shared.UI.UrlBuilder;
 @inject IOptionsMonitor<MaMenuConfiguration> OptionsAccessor
 
 @{
@@ -12,21 +12,6 @@
 }
 
 @functions {
-    private static string GetLink(SiteConfiguration config, string routeName = null)
-    {
-        return string.IsNullOrWhiteSpace(routeName) ? config.RootUrl : config.RootUrl + config.Routes[routeName];
-    }
-
-    private static string GetLink(SiteConfiguration config, string routeName, string accountId)
-    {
-        return string.Format(config.RootUrl + config.Routes[routeName], accountId);
-    }
-
-    private static string GetLink(SiteConfiguration config, string routeName, string clientId, string returnUrl)
-    {
-        return string.Format(config.RootUrl + config.Routes[routeName], clientId, returnUrl);
-    }
-
     private bool IsErrorPage()
     {
         if (ViewBag.IsErrorPage is bool)

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Menu.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_Menu.cshtml
@@ -44,26 +44,32 @@
 <div class="das-account-header das-account-header--employer">
     <div class="govuk-width-container">
         <p class="das-account-header__title">Your employer account</p>
-        <nav class="das-user-navigation" id="user-nav">
+        <nav class="das-user-navigation" id="das-user-navigation">
             <ul class="das-user-navigation__list" role="menu">
                 <li role="menuitem" class="das-user-navigation__list-item">
                     <a href='@GetLink(externalLinks.Ma, "Help")' class="das-user-navigation__link">Help</a>
                 </li>
                 @if (Context.User.Identity.IsAuthenticated)
                 {
-                    <li class="has-sub-menu">
+                    <li role="menuitem" class="das-user-navigation__list-item das-user-navigation__list-item--has-sub-menu">
                         <a href="/" role="menuitem" class="das-user-navigation__link">Settings</a>
-                        <ul role="menu" id="settings-menu" class="js-hidden">
-                            <li><a href='@GetLink(externalLinks.Ma, "Accounts", accountId)' role="menuitem" class="sub-menu-item">Your accounts</a></li>
+                        <ul role="menu" class="das-user-navigation__sub-menu js-hidden">
+                            <li class="das-user-navigation__sub-menu-list-item" role="menuitem">
+                                <a href='@GetLink(externalLinks.Ma, "Accounts", accountId)' role="menuitem" class="das-user-navigation__sub-menu-link">Your accounts</a>
+                            </li>
                             @if(!IsErrorPage())
                             {
-                                <li><a href='@GetLink(externalLinks.Ma, "RenameAccount", accountId)' class="sub-menu-item">Rename account</a></li>
+                                <li class="das-user-navigation__sub-menu-list-item" role="menuitem">
+                                    <a href='@GetLink(externalLinks.Ma, "RenameAccount", accountId)' class="das-user-navigation__sub-menu-link">Rename account</a></li>
                             }
-                            <li><a href='@GetLink(externalLinks.Identity, "ChangePassword", clientId, GetEncodedReturnUrl(Context.Request))' class="sub-menu-item">Change your password</a></li>
-                            <li><a href='@GetLink(externalLinks.Identity, "ChangeEmailAddress", clientId, GetEncodedReturnUrl(Context.Request))' class="sub-menu-item">Change your email address</a></li>
+                            <li class="das-user-navigation__sub-menu-list-item" role="menuitem">
+                                <a href='@GetLink(externalLinks.Identity, "ChangePassword", clientId, GetEncodedReturnUrl(Context.Request))' class="das-user-navigation__sub-menu-link">Change your password</a></li>
+                            <li class="das-user-navigation__sub-menu-list-item" role="menuitem">
+                                <a href='@GetLink(externalLinks.Identity, "ChangeEmailAddress", clientId, GetEncodedReturnUrl(Context.Request))' class="das-user-navigation__sub-menu-link">Change your email address</a></li>
                             @if(!IsErrorPage())
                             {
-                                <li><a href='@GetLink(externalLinks.Ma, "Notifications")' class="sub-menu-item">Notifications settings</a></li>
+                                <li class="das-user-navigation__sub-menu-list-item" role="menuitem">
+                                    <a href='@GetLink(externalLinks.Ma, "Notifications")' class="das-user-navigation__sub-menu-link">Notifications settings</a></li>
                             }
                         </ul>
                     </li>

--- a/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_ViewImports.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI/Views/Shared/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@using SFA.DAS.Employer.Shared.UI.Configuration
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/SFA.DAS.Employer.Shared.UI/example-website/.vscode/launch.json
+++ b/SFA.DAS.Employer.Shared.UI/example-website/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/bin/Debug/netcoreapp2.2/DfE.Example.Web.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart",
+            "launchBrowser": {
+                "enabled": true,
+                "args": "${auto-detect-url}",
+                "windows": {
+                    "command": "cmd.exe",
+                    "args": "/C start ${auto-detect-url}"
+                },
+                "osx": {
+                    "command": "open"
+                },
+                "linux": {
+                    "command": "xdg-open"
+                }
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ,]
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/.vscode/tasks.json
+++ b/SFA.DAS.Employer.Shared.UI/example-website/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/example-website.csproj",
+                "/p:GenerateFullPaths=true"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/Configuration/CdnConfig.cs
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Configuration/CdnConfig.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace DfE.Example.Web.Configuration
+{
+    public class CdnConfig
+    {
+        public Uri Url { get; set; }
+    }
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/Configuration/RouteNames.cs
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Configuration/RouteNames.cs
@@ -1,0 +1,7 @@
+namespace DfE.Example.Web.Configuration
+{
+    public static class RouteNames
+    {
+        public const string Logout_Get = "Logout_Get";
+    }
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/Controllers/ErrorController.cs
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Controllers/ErrorController.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+using System.Net;
+using DfE.Example.Web.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.Example.Web.Controllers
+{
+    [AllowAnonymous]
+    public class ErrorController : Controller
+    {        
+        [Route("error/{id?}")]
+        [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+        public IActionResult Error(int id)
+        {
+            Response.StatusCode = id;
+
+            return View(GetViewNameForStatus(id), new ErrorViewModel { StatusCode = id, RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
+        }
+
+        private string GetViewNameForStatus(int statusCode)
+        {
+            switch(statusCode)
+            {
+                case (int)HttpStatusCode.NotFound:
+                    return "PageNotFound";
+                case (int)HttpStatusCode.Forbidden:
+                case (int)HttpStatusCode.Unauthorized:
+                    return "AccessDenied";
+                default:
+                    return "Error";
+            }
+        }
+    }
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/Controllers/HomeController.cs
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Controllers/HomeController.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+using DfE.Example.Web.Configuration;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace DfE.Example.Web.Controllers
+{
+    public class HomeController : Controller
+    {
+        private readonly ILogger<HomeController> _logger;
+
+        public HomeController(ILogger<HomeController> logger)
+        {
+            _logger = logger;
+        }
+
+        public IActionResult Index()
+        {
+            return View();
+        }
+
+        [HttpGet, Route("logout", Name = RouteNames.Logout_Get)]
+        public async Task Logout()
+        {
+            await HttpContext.SignOutAsync("Cookies");
+
+            await HttpContext.SignOutAsync("oidc");
+        }
+    }
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/Models/ErrorViewModel.cs
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Models/ErrorViewModel.cs
@@ -1,0 +1,9 @@
+namespace DfE.Example.Web.Models
+{
+    public class ErrorViewModel
+    {
+        public int StatusCode { get; set; }
+        public string RequestId { get; set; }
+        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+    }
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/Program.cs
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Program.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.IO;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using SFA.DAS.Configuration.AzureTableStorage;
+
+namespace DfE.Example.Web
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        private static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .ConfigureKestrel(c => c.AddServerHeader = false)
+                .UseStartup<Startup>()
+                .ConfigureAppConfiguration((hostingContext, config) =>
+                {
+                    var environmentName = hostingContext.HostingEnvironment.EnvironmentName;
+                    config.SetBasePath(Directory.GetCurrentDirectory());
+                    config.AddJsonFile("appSettings.json", optional: false, reloadOnChange: false);
+                    config.AddAzureTableStorage(options => {
+                        options.ConfigurationKeys = new [] { "SFA.DAS.Employer.Shared.UI" };
+                        options.EnvironmentNameEnvironmentVariableName = "APPSETTING_EnvironmentName";
+                        options.StorageConnectionStringEnvironmentVariableName = "APPSETTING_ConfigurationStorageConnectionString";
+                    });
+                    config.AddUserSecrets<Startup>();
+                    config.AddEnvironmentVariables();
+                })
+                .UseUrls("https://localhost:5040");
+    }
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/README.md
+++ b/SFA.DAS.Employer.Shared.UI/example-website/README.md
@@ -1,0 +1,12 @@
+# Example Website
+
+This project is an example of how to use the shared menu package. 
+
+
+## Setup
+
+1. Update the *appSetting.json* file. Add setting for the **oidc** section with some valid employer idams values.
+2. Ensure the Kestral port is the same as that configured for the relying party in step 1.
+3. Run Azure Storage Emulator
+4. Either create the config row with RowKey *SFA.DAS.Employer.Shared.UI_1.0* manually based on contents from the configuration repository OR use the *das-config-updater* tool to generate all application configurations.
+5. Run the project. 

--- a/SFA.DAS.Employer.Shared.UI/example-website/Security/OidcConfiguration.cs
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Security/OidcConfiguration.cs
@@ -1,0 +1,11 @@
+namespace DfE.Example.Web.Security
+{
+    public class OidcConfiguration
+    {
+        public const int SessionTimeoutMinutes = 30;
+        public string Authority { get; set; }
+        public string MetaDataAddress { get; set; }
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+    }   
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/Security/SecurityServicesCollectionExtensions.cs
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Security/SecurityServicesCollectionExtensions.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using DfE.Example.Web;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace DfE.Example.Web.Security
+{
+    public static class SecurityServicesCollectionExtensions
+    {
+        public static void AddAuthenticationService(this IServiceCollection services, OidcConfiguration authConfiguration, IHostingEnvironment hostingEnvironment)
+        {
+            var authConfig = authConfiguration;
+
+            JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+
+            services.AddAuthentication(options =>
+            {
+                options.DefaultScheme = "Cookies";
+                options.DefaultChallengeScheme = "oidc";
+            })
+            .AddCookie("Cookies", options =>
+            {
+                options.Cookie.Name = "example-auth";
+
+                if (!hostingEnvironment.IsDevelopment())
+                {
+                    options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.Always;
+                    options.SlidingExpiration = true;
+                    options.ExpireTimeSpan = TimeSpan.FromMinutes(OidcConfiguration.SessionTimeoutMinutes);
+                }
+
+                options.AccessDeniedPath = "/Error/403";
+            })
+            .AddOpenIdConnect("oidc", options =>
+            {
+                options.SignInScheme = "Cookies";
+                options.Authority = authConfig.Authority;
+                options.MetadataAddress = authConfig.MetaDataAddress;
+                options.RequireHttpsMetadata = false;
+                options.ResponseType = "code";
+                options.ClientId = authConfig.ClientId;
+                options.ClientSecret = authConfig.ClientSecret;
+                options.Scope.Add("profile");
+            });
+        }
+    }
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/Startup.cs
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Startup.cs
@@ -1,0 +1,78 @@
+using DfE.Example.Web.Configuration;
+using DfE.Example.Web.Security;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SFA.DAS.Employer.Shared.UI;
+
+namespace DfE.Example.Web
+{
+    public partial class Startup
+    {
+        public IConfiguration Configuration { get; }
+        private IHostingEnvironment _hostingEnvironment;
+        private readonly OidcConfiguration _authConfig;
+
+        public Startup(IConfiguration configuration, IHostingEnvironment env)
+        {
+            Configuration = configuration;
+            _hostingEnvironment = env;
+            _authConfig = Configuration.GetSection("Oidc").Get<OidcConfiguration>();
+        }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
+                options.CheckConsentNeeded = context => true;
+                options.MinimumSameSitePolicy = SameSiteMode.None;
+            });
+
+            services.AddMvc(options =>
+            {
+                //options.Filters.Add(new AuthorizeFilter("EmployerAccountPolicy"));
+                options.Filters.Add(new AuthorizeFilter());
+
+            }).SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+
+            services.AddMaMenuConfiguration(Configuration, RouteNames.Logout_Get, _authConfig.ClientId);
+
+            services.AddAuthenticationService(_authConfig, _hostingEnvironment);
+            //services.AddAuthorizationService();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Home/Error");
+                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+                app.UseHsts();
+            }
+
+            app.UseAuthentication();
+
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+            app.UseCookiePolicy();
+
+            app.UseMvc(routes =>
+            {
+                routes.MapRoute(
+                    name: "default",
+                    template: "{controller=Home}/{action=Index}/{id?}");
+            });
+        }
+    }
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/Views/Error/AccessDenied.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Views/Error/AccessDenied.cshtml
@@ -1,0 +1,9 @@
+@model ErrorViewModel
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Access denied</h1>
+        <p class="govuk-body">Your account does not have sufficient privileges</p>
+        <p><a href="/" class="govuk-button">Go back to the service homepage</a></p>
+    </div>
+</div>

--- a/SFA.DAS.Employer.Shared.UI/example-website/Views/Error/Error.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Views/Error/Error.cshtml
@@ -1,0 +1,8 @@
+@model ErrorViewModel
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+        <p class="govuk-body">The Error code is @Model.StatusCode.</p>
+        <p class="govuk-body">Try again later.</p>
+    </div>
+</div>

--- a/SFA.DAS.Employer.Shared.UI/example-website/Views/Error/PageNotFound.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Views/Error/PageNotFound.cshtml
@@ -1,0 +1,13 @@
+@model ErrorViewModel
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Page not found</h1>
+        <p class="govuk-body">
+            If you typed the web address, check it is correct.
+        </p>
+        <p class="govuk-body">
+            If you pasted the web address, check you copied the entire address.
+        </p>
+    </div>
+</div>

--- a/SFA.DAS.Employer.Shared.UI/example-website/Views/Home/Index.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Views/Home/Index.cshtml
@@ -1,0 +1,8 @@
+﻿@{
+    ViewData["Title"] = "Home Page";
+}
+
+
+    <h1 class="govuk-heading-xl">Welcome</h1>
+
+

--- a/SFA.DAS.Employer.Shared.UI/example-website/Views/Shared/_Layout.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Views/Shared/_Layout.cshtml
@@ -1,0 +1,64 @@
+﻿@{
+    string accountId = (string)this.ViewContext.RouteData.Values["employerAccountId"];
+    ViewBag.HideHeaderBorder = true; 
+}
+<!DOCTYPE html>
+<html lang="en" class="govuk-template ">
+<head>
+  <meta charset="utf-8" />
+  <title>@ViewData["Title"]</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#0b0c0c" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon" />
+  <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/govuk-apple-touch-icon-180x180.png" />
+  <link rel="apple-touch-icon" sizes="167x167" href="/assets/images/govuk-apple-touch-icon-167x167.png" />
+  <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/govuk-apple-touch-icon-152x152.png" />
+  <link rel="apple-touch-icon" href="/assets/images/govuk-apple-touch-icon.png" />
+  <!--[if !IE 8]><!-->
+    <link href="/css/main.css" rel="stylesheet" />
+    <!--<![endif]-->
+    
+  <!--[if IE 8]>
+    
+  <![endif]-->
+
+  <link href="/css/application.css" rel="stylesheet" no-cdn/>
+
+  <!--[if lt IE 9]>
+    <script src="/libs/html5-shiv/html5shiv.js"></script>
+  <![endif]-->
+  <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
+
+</head>
+<body class="govuk-template__body ">
+  <script nws-csp-add-nonce="true">
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+  </script>
+  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+
+  <partial name="_Header">
+  <partial name="_Menu" model="@accountId">
+  <div class="govuk-width-container app-account-header">
+    @RenderSection("BodyHeader", required: false)
+  </div>
+
+  <div class="das-section--dashboard">
+    <div class="govuk-width-container" >
+      <main class="govuk-main-wrapper" id="main-content" role="main">
+        @RenderBody()
+      </main>
+    </div>
+  </div>
+  <partial name="_Footer">
+<script src="/libs/govuk-frontend/all.js"></script>
+<script src="/libs/jquery/jquery.min.js"></script>
+<script src="/js/das-all.js"></script>
+<script src="/js/app.min.js"></script>
+<script>
+    window.GOVUKFrontend.initAll();
+    window.DASFrontend.initAll();
+</script>
+</body>
+</html>

--- a/SFA.DAS.Employer.Shared.UI/example-website/Views/_ViewImports.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Views/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+﻿@using DfE.Example.Web.Models
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, WebEssentials.AspNetCore.CdnTagHelpers

--- a/SFA.DAS.Employer.Shared.UI/example-website/Views/_ViewStart.cshtml
+++ b/SFA.DAS.Employer.Shared.UI/example-website/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout";
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/appsettings.Development.json
+++ b/SFA.DAS.Employer.Shared.UI/example-website/appsettings.Development.json
@@ -1,0 +1,12 @@
+{
+  "EnvironmentName": "LOCAL",  
+  "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true",
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/appsettings.json
+++ b/SFA.DAS.Employer.Shared.UI/example-website/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "EnvironmentName": "",
+  "ConfigurationStorageConnectionString": "",
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Oidc": {
+    "Authority": "",
+    "MetaDataAddress": "",
+    "ClientId": "",
+    "ClientSecret": ""
+  },
+  "cdn": {
+    "url": "https://das-at-frnt-end.azureedge.net"
+  }
+}

--- a/SFA.DAS.Employer.Shared.UI/example-website/example-website.csproj
+++ b/SFA.DAS.Employer.Shared.UI/example-website/example-website.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <RootNamespace>DfE.Example.Web</RootNamespace>
+    <AssemblyName>DfE.Example.Web</AssemblyName>
+    <UserSecretsId>employer-favourites-web</UserSecretsId>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App"/>
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All"/>
+    <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.19"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0"/>
+    <PackageReference Include="SFA.DAS.Employer.Shared.UI" Version="1.0.4"/>
+    <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.16"/>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The purpose of this package is to allow the sharing of the employer menu layout and functionality.
**Note:** Time spent on this has been minimal so expecting there to be improvement / tidy-up comments 😄 

The package is currently only consumed by Employer-Favourites (https://github.com/SkillsFundingAgency/das-employer-favourites/pull/19). I would expect there'll probably be some changes required to accommodate nuances of other apps.

Provides the following partial views (See readme in the package [folder](https://github.com/SkillsFundingAgency/das-shared-packages/tree/employer-menu/SFA.DAS.Employer.Shared.UI/SFA.DAS.Employer.Shared.UI) for more info):
- Menu 
- Header
- Footer

Configuration is shared between apps via table storage. (This is currently tied to the Employer-Favourites deployment). There's a meeting with DevOps to discuss the best option for this going forward.