### PR TITLE
Add flag to prevent prefixing of configuration variables

### DIFF
--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationProvider.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationProvider.cs
@@ -16,12 +16,14 @@ namespace SFA.DAS.Configuration.AzureTableStorage
         private readonly CloudStorageAccount _storageAccount;
         private readonly string _environmentName;
         private readonly IEnumerable<string> _configurationKeys;
+        private readonly bool _prefixConfigurationKeys;
 
-        public AzureTableStorageConfigurationProvider(CloudStorageAccount cloudStorageAccount, string environmentName, IEnumerable<string> configurationKeys)
+        public AzureTableStorageConfigurationProvider(CloudStorageAccount cloudStorageAccount, string environmentName, IEnumerable<string> configurationKeys, bool prefixConfigurationKeys)
         {
             _storageAccount = cloudStorageAccount;
             _environmentName = environmentName;
             _configurationKeys = configurationKeys;
+            _prefixConfigurationKeys = prefixConfigurationKeys;
         }
         
         public override void Load()
@@ -48,7 +50,14 @@ namespace SFA.DAS.Configuration.AzureTableStorage
 
                 foreach (var keyValuePair in parsedData)
                 {
-                    data.AddOrUpdate($"{configurationKey}:{keyValuePair.Key}", keyValuePair.Value, (k, v) => keyValuePair.Value);
+                    if (_prefixConfigurationKeys)
+                    {
+                        data.AddOrUpdate($"{configurationKey}:{keyValuePair.Key}", keyValuePair.Value, (k, v) => keyValuePair.Value);
+                    }
+                    else
+                    {
+                        data.AddOrUpdate($"{keyValuePair.Key}", keyValuePair.Value, (k, v) => keyValuePair.Value);
+                    }
                 }
             }
         }

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationSource.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationSource.cs
@@ -9,17 +9,19 @@ namespace SFA.DAS.Configuration.AzureTableStorage
         private readonly string _connectionString;
         private readonly string _environmentName;
         private readonly IEnumerable<string> _configurationKeys;
+        private readonly bool _prefixConfigurationKeys;
 
-        public AzureTableStorageConfigurationSource(string connectionString, string environmentName, IEnumerable<string> configurationKeys)
+        public AzureTableStorageConfigurationSource(ConfigurationOptions configOptions)
         {
-            _connectionString = connectionString;
-            _environmentName = environmentName;
-            _configurationKeys = configurationKeys;
+            _connectionString = configOptions.EnvironmentVariableKeys.TableStorageConnectionString;
+            _environmentName = configOptions.EnvironmentVariableKeys.EnvironmentName;
+            _configurationKeys = configOptions.ConfigurationKeys;
+            _prefixConfigurationKeys = configOptions.PrefixConfigurationKeys;
         }
 
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return new AzureTableStorageConfigurationProvider(CloudStorageAccount.Parse(_connectionString), _environmentName, _configurationKeys);
+            return new AzureTableStorageConfigurationProvider(CloudStorageAccount.Parse(_connectionString), _environmentName, _configurationKeys, _prefixConfigurationKeys);
         }
     }
 }

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationBootstrapper.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationBootstrapper.cs
@@ -7,17 +7,17 @@ namespace SFA.DAS.Configuration.AzureTableStorage
         private const string DeveloperEnvironmentName = "LOCAL";
         private const string DeveloperEnvironmentDefaultConnectionString = "UseDevelopmentStorage=true";
 
-        public static (string ConnectionString, string EnvironmentName) GetEnvironmentVariables()
+        public static EnvironmentVariables GetEnvironmentVariables()
         {
             return GetRequiredEnvironmentVariables(EnvironmentVariableNames.ConfigurationStorageConnectionString, EnvironmentVariableNames.EnvironmentName);
         }
 
-        public static (string ConnectionString, string EnvironmentName) GetEnvironmentVariables(string connectionStringKey, string environmentNameKey)
+        public static EnvironmentVariables GetEnvironmentVariables(string connectionStringKey, string environmentNameKey)
         {
             return GetRequiredEnvironmentVariables(connectionStringKey, environmentNameKey);
         }
 
-        private static (string ConnectionString, string EnvironmentName) GetRequiredEnvironmentVariables(string connectionStringKey, string environmentNameKey)
+        private static EnvironmentVariables GetRequiredEnvironmentVariables(string connectionStringKey, string environmentNameKey)
         {
             var environmentName = Environment.GetEnvironmentVariable(environmentNameKey) ?? DeveloperEnvironmentName;
             var connectionString = Environment.GetEnvironmentVariable(connectionStringKey);
@@ -34,7 +34,7 @@ namespace SFA.DAS.Configuration.AzureTableStorage
                 }
             }
 
-            return (connectionString, environmentName);
+            return new EnvironmentVariables(connectionString, environmentName);
         }
     }
 }

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationBuilderExtensions.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationBuilderExtensions.cs
@@ -4,26 +4,6 @@ using Microsoft.Extensions.Configuration;
 
 namespace SFA.DAS.Configuration.AzureTableStorage
 {
-    public class ConfigurationOptions
-    {
-        public EnvironmentVariables EnvironmentVariableKeys { get; set; }
-        public string[] ConfigurationKeys { get; set; }
-        public bool PrefixConfigurationKeys { get; set; } = true;
-    }
-
-    public class EnvironmentVariables
-    {
-        public EnvironmentVariables(string tableStorageConnectionString, string environmentName)
-        {
-            TableStorageConnectionString = tableStorageConnectionString;
-            EnvironmentName = environmentName;
-        }
-
-        public string TableStorageConnectionString { get; set; }
-        public string EnvironmentName { get; set; }
-    }
-
-
     public static class ConfigurationBuilderExtensions
     {
         public static IConfigurationBuilder AddAzureTableStorage(this IConfigurationBuilder builder, params string[] configurationKeys)
@@ -33,11 +13,11 @@ namespace SFA.DAS.Configuration.AzureTableStorage
                 throw new ArgumentException("At least one configuration key is required", nameof(configurationKeys));
             }
             
-            var (ConnectionStringKey, EnvironmentNameKey) = ConfigurationBootstrapper.GetEnvironmentVariables();
+            var environmentVariables = ConfigurationBootstrapper.GetEnvironmentVariables();
 
             var configOptions = new ConfigurationOptions
             {
-                EnvironmentVariableKeys = new EnvironmentVariables(ConnectionStringKey, EnvironmentNameKey),
+                EnvironmentVariableKeys = environmentVariables,
                 ConfigurationKeys = configurationKeys
             };
 
@@ -69,11 +49,11 @@ namespace SFA.DAS.Configuration.AzureTableStorage
             var environmentNameKey = string.IsNullOrWhiteSpace(options.EnvironmentNameEnvironmentVariableName) ? EnvironmentVariableNames.EnvironmentName : options.EnvironmentNameEnvironmentVariableName;
             var storageConnectionStringKey = string.IsNullOrWhiteSpace(options.StorageConnectionStringEnvironmentVariableName) ? EnvironmentVariableNames.ConfigurationStorageConnectionString : options.StorageConnectionStringEnvironmentVariableName;
 
-            var (ConnectionStringKey, EnvironmentNameKey) = ConfigurationBootstrapper.GetEnvironmentVariables(storageConnectionStringKey, environmentNameKey);
+            var environmentVariables = ConfigurationBootstrapper.GetEnvironmentVariables(storageConnectionStringKey, environmentNameKey);
 
             var configOptions = new ConfigurationOptions
             {
-                EnvironmentVariableKeys = new EnvironmentVariables(ConnectionStringKey, EnvironmentNameKey),
+                EnvironmentVariableKeys = environmentVariables,
                 ConfigurationKeys = options.ConfigurationKeys,
                 PrefixConfigurationKeys = options.PreFixConfigurationKeys
             };

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationOptions.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.Configuration.AzureTableStorage
+{
+    public class ConfigurationOptions
+    {
+        public EnvironmentVariables EnvironmentVariableKeys { get; set; }
+        public string[] ConfigurationKeys { get; set; }
+        public bool PrefixConfigurationKeys { get; set; } = true;
+    }
+}

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/EnvironmentVariables.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/EnvironmentVariables.cs
@@ -1,0 +1,14 @@
+﻿namespace SFA.DAS.Configuration.AzureTableStorage
+{
+    public class EnvironmentVariables
+    {
+        public EnvironmentVariables(string tableStorageConnectionString, string environmentName)
+        {
+            TableStorageConnectionString = tableStorageConnectionString;
+            EnvironmentName = environmentName;
+        }
+
+        public string TableStorageConnectionString { get; set; }
+        public string EnvironmentName { get; set; }
+    }
+}

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/StorageOptions.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/StorageOptions.cs
@@ -5,5 +5,6 @@ namespace SFA.DAS.Configuration.AzureTableStorage
         public string EnvironmentNameEnvironmentVariableName { get; set; }
         public string StorageConnectionStringEnvironmentVariableName { get; set; }
         public string[] ConfigurationKeys { get; set; }
+        public bool PreFixConfigurationKeys { get; set; } = true;
     }
 }

--- a/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBootstrapperTests.cs
+++ b/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBootstrapperTests.cs
@@ -58,7 +58,7 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
         [TestCase("DEMO")]
         public void WhenGettingEnvironmentVariablesByCustomNames_EnvironmentVariablesAreSet_ThenValuesFromEnvironmentVariablesAreProvided(string environmentName)
         {
-            Test(f => f.SetEnvironmentVariables(storageConnectionString: (Fix.CustomStorageKey, Fix.CustomStorageValue), environmentName: (Fix.CustomEnvironmentKey,Fix.CustomEnvironmentValue)), f => f.GetEnvironmentVariables(Fix.CustomStorageKey, Fix.CustomEnvironmentKey), (f, r) => f.AssertValues(r.StorageConnectionString, r.EnvironmentName));
+            Test(f => f.SetEnvironmentVariables(storageConnectionString: (Fix.CustomStorageKey, Fix.CustomStorageValue), environmentName: (Fix.CustomEnvironmentKey,Fix.CustomEnvironmentValue)), f => f.GetEnvironmentVariables(Fix.CustomStorageKey, Fix.CustomEnvironmentKey), (f, r) => f.AssertValues(r.TableStorageConnectionString, r.EnvironmentName));
         }
     }
 
@@ -92,17 +92,17 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
                 _expectedStorageConnectionValue = storageConnectionString;
         }
 
-        public (string StorageConnectionString, string EnvironmentName) GetEnvironmentVariables()
+        public EnvironmentVariables GetEnvironmentVariables()
         {
             return ConfigurationBootstrapper.GetEnvironmentVariables();
         }
 
-        public (string StorageConnectionString, string EnvironmentName) GetEnvironmentVariables(string connectionStringKey, string environmentKey)
+        public EnvironmentVariables GetEnvironmentVariables(string connectionStringKey, string environmentKey)
         {
             return ConfigurationBootstrapper.GetEnvironmentVariables(connectionStringKey, environmentKey);
         }
 
-        public void AssertAreDefaults((string StorageConnectionString, string EnvironmentName) retrievedValues)
+        public void AssertAreDefaults(EnvironmentVariables retrievedValues)
         {
             AssertValues("UseDevelopmentStorage=true", "LOCAL");
         }


### PR DESCRIPTION
To give the option of configuration keys not being prefixed with the RowKey Name a flag can now be passed.

This allows the json configuration structure to remain the same whether using appSetting.json, secrets.json or Azure Table Storage.

The down side is that if you do you multiple azure configurations then a collision of names is possible.
