### PR TITLE
Make data dictionary case insensitive

### DIFF
--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationProvider.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,7 +31,7 @@ namespace SFA.DAS.Configuration.AzureTableStorage
         {
             var client = _storageAccount.CreateCloudTableClient();
             var table = client.GetTableReference(ConfigurationTableName);
-            var data = new ConcurrentDictionary<string, string>();
+            var data = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var tasks = _configurationKeys.Select(k => GetTableRowData(table, k, data));
             
             Task.WhenAll(tasks).ConfigureAwait(false).GetAwaiter().GetResult();


### PR DESCRIPTION
Unlike the other providers the Azure table storage configuration provider wasn't making it's dictionary case insensitive. Which meant when looking for property names from the object it was binding to it wouldn't match. 🐐 