### PR TITLE
Don't exception if the process can't start.

### DIFF
--- a/SFA.DAS.Testing/SFA.DAS.Testing.AzureStorageEmulator/AzureStorageEmulatorManager.cs
+++ b/SFA.DAS.Testing/SFA.DAS.Testing.AzureStorageEmulator/AzureStorageEmulatorManager.cs
@@ -16,7 +16,7 @@ namespace SFA.DAS.Testing.AzureStorageEmulator
                 {
                     if (process == null)
                     {
-                        throw new InvalidOperationException("Unable to start process.");
+                        return false;
                     }
 
                     status = GetStatus(process);

--- a/SFA.DAS.Testing/SFA.DAS.Testing.AzureStorageEmulator/AzureStorageEmulatorManager.cs
+++ b/SFA.DAS.Testing/SFA.DAS.Testing.AzureStorageEmulator/AzureStorageEmulatorManager.cs
@@ -8,27 +8,40 @@ namespace SFA.DAS.Testing.AzureStorageEmulator
     {
         public static bool IsProcessRunning()
         {
-            bool status;
-
-            using (Process process = Process.Start(StorageEmulatorProcessFactory.Create(ProcessCommand.Status)))
+            try
             {
-                if (process == null)
+                bool status;
+
+                using (Process process = Process.Start(StorageEmulatorProcessFactory.Create(ProcessCommand.Status)))
                 {
-                    throw new InvalidOperationException("Unable to start process.");
+                    if (process == null)
+                    {
+                        throw new InvalidOperationException("Unable to start process.");
+                    }
+
+                    status = GetStatus(process);
+                    process.WaitForExit();
                 }
 
-                status = GetStatus(process);
-                process.WaitForExit();
+                return status;
             }
-
-            return status;
+            catch
+            {
+                return false;
+            }
         }
 
         public static void StartStorageEmulator()
         {
-            if (!IsProcessRunning())
+            try
             {
-                ExecuteProcess(ProcessCommand.Start);
+                if (!IsProcessRunning())
+                {
+                    ExecuteProcess(ProcessCommand.Start);
+                }
+            }
+            catch
+            {
             }
         }
 
@@ -48,16 +61,11 @@ namespace SFA.DAS.Testing.AzureStorageEmulator
             {
                 if (process == null)
                 {
-                    throw new InvalidOperationException("Unable to start process.");
+                    return;
                 }
 
                 error = GetError(process);
                 process.WaitForExit();
-            }
-
-            if (!String.IsNullOrEmpty(error))
-            {
-                throw new InvalidOperationException(error);
             }
         }
 


### PR DESCRIPTION
I just realised it needs to gracefully handle the process not being able to start.  Chances are the build server and AT won't have the emulator installed!