### PR TITLE
Configuration: Add option to directly pass StorageConnectionString & EnvironmentName

### DIFF
--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationSource.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationSource.cs
@@ -13,8 +13,8 @@ namespace SFA.DAS.Configuration.AzureTableStorage
 
         public AzureTableStorageConfigurationSource(ConfigurationOptions configOptions)
         {
-            _connectionString = configOptions.EnvironmentVariableKeys.TableStorageConnectionString;
-            _environmentName = configOptions.EnvironmentVariableKeys.EnvironmentName;
+            _connectionString = configOptions.TableStorageConnectionString;
+            _environmentName = configOptions.EnvironmentName;
             _configurationKeys = configOptions.ConfigurationKeys;
             _prefixConfigurationKeys = configOptions.PrefixConfigurationKeys;
         }

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationSource.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationSource.cs
@@ -6,22 +6,22 @@ namespace SFA.DAS.Configuration.AzureTableStorage
 {
     public class AzureTableStorageConfigurationSource : IConfigurationSource
     {
-        private readonly string _connectionString;
-        private readonly string _environmentName;
-        private readonly IEnumerable<string> _configurationKeys;
-        private readonly bool _prefixConfigurationKeys;
+        internal readonly string ConnectionString;
+        internal readonly string EnvironmentName;
+        internal readonly IEnumerable<string> ConfigurationKeys;
+        internal readonly bool PrefixConfigurationKeys;
 
         public AzureTableStorageConfigurationSource(ConfigurationOptions configOptions)
         {
-            _connectionString = configOptions.TableStorageConnectionString;
-            _environmentName = configOptions.EnvironmentName;
-            _configurationKeys = configOptions.ConfigurationKeys;
-            _prefixConfigurationKeys = configOptions.PrefixConfigurationKeys;
+            ConnectionString = configOptions.TableStorageConnectionString;
+            EnvironmentName = configOptions.EnvironmentName;
+            ConfigurationKeys = configOptions.ConfigurationKeys;
+            PrefixConfigurationKeys = configOptions.PrefixConfigurationKeys;
         }
 
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return new AzureTableStorageConfigurationProvider(CloudStorageAccount.Parse(_connectionString), _environmentName, _configurationKeys, _prefixConfigurationKeys);
+            return new AzureTableStorageConfigurationProvider(CloudStorageAccount.Parse(ConnectionString), EnvironmentName, ConfigurationKeys, PrefixConfigurationKeys);
         }
     }
 }

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationBootstrapper.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationBootstrapper.cs
@@ -19,9 +19,21 @@ namespace SFA.DAS.Configuration.AzureTableStorage
 
         private static EnvironmentVariables GetRequiredEnvironmentVariables(string connectionStringKey, string environmentNameKey)
         {
-            var environmentName = Environment.GetEnvironmentVariable(environmentNameKey) ?? DeveloperEnvironmentName;
+            var environmentName = GetEnvironmentNameFromEnvironmentVariable(environmentNameKey);
+            var connectionString = GetConnectionStringFromEnvironmentVariable(connectionStringKey, environmentName);
+
+            return new EnvironmentVariables(connectionString, environmentName);
+        }
+
+        internal static string GetEnvironmentNameFromEnvironmentVariable(string environmentNameKey)
+        {
+            return Environment.GetEnvironmentVariable(environmentNameKey) ?? DeveloperEnvironmentName;
+        }
+        
+        internal static string GetConnectionStringFromEnvironmentVariable(string connectionStringKey, string environmentName)
+        {
             var connectionString = Environment.GetEnvironmentVariable(connectionStringKey);
-            
+
             if (string.IsNullOrWhiteSpace(connectionString))
             {
                 if (string.Equals(environmentName, DeveloperEnvironmentName, StringComparison.OrdinalIgnoreCase))
@@ -34,7 +46,7 @@ namespace SFA.DAS.Configuration.AzureTableStorage
                 }
             }
 
-            return new EnvironmentVariables(connectionString, environmentName);
+            return connectionString;
         }
     }
 }

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationBuilderExtensions.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationBuilderExtensions.cs
@@ -52,19 +52,16 @@ namespace SFA.DAS.Configuration.AzureTableStorage
                 PrefixConfigurationKeys = options.PreFixConfigurationKeys
             };
 
-            if (options.EnvironmentName == null
-                || options.StorageConnectionString == null)
-            {
-                var environmentVariables = ConfigurationBootstrapper.GetEnvironmentVariables(
-                    options.StorageConnectionStringEnvironmentVariableName,
+            configOptions.EnvironmentName = options.EnvironmentName ??
+                ConfigurationBootstrapper.GetEnvironmentNameFromEnvironmentVariable(
                     options.EnvironmentNameEnvironmentVariableName);
+            
+            configOptions.TableStorageConnectionString = options.StorageConnectionString ??
+                ConfigurationBootstrapper.GetConnectionStringFromEnvironmentVariable(
+                    options.StorageConnectionStringEnvironmentVariableName, configOptions.EnvironmentName);
 
-                configOptions.EnvironmentName = options.EnvironmentName ?? environmentVariables.EnvironmentName;
-                configOptions.TableStorageConnectionString = options.StorageConnectionString ?? environmentVariables.TableStorageConnectionString;
-            }
-            
             var configurationSource = new AzureTableStorageConfigurationSource(configOptions);
-            
+
             return builder.Add(configurationSource);
         }
     }

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationOptions.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationOptions.cs
@@ -2,7 +2,8 @@
 {
     public class ConfigurationOptions
     {
-        public EnvironmentVariables EnvironmentVariableKeys { get; set; }
+        public string EnvironmentName { get; set; }
+        public string TableStorageConnectionString { get; set; }
         public string[] ConfigurationKeys { get; set; }
         public bool PrefixConfigurationKeys { get; set; } = true;
     }

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/StorageOptions.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/StorageOptions.cs
@@ -2,8 +2,22 @@ namespace SFA.DAS.Configuration.AzureTableStorage
 {
     public class StorageOptions
     {
+        /// <summary>
+        /// Get EnvironmentName from the value of this given environment variable.
+        /// </summary>
         public string EnvironmentNameEnvironmentVariableName { get; set; }
+        /// <summary>
+        /// Get StorageConnectionString from the value of this given environment variable.
+        /// </summary>
         public string StorageConnectionStringEnvironmentVariableName { get; set; }
+        /// <summary>
+        /// Directly supply EnvironmentName (overrides getting value from environment variable specified by EnvironmentNameEnvironmentVariableName).
+        /// </summary>
+        public string EnvironmentName { get; set; }
+        /// <summary>
+        /// Directly supply StorageConnectionString (overrides getting value from environment variable specified by StorageConnectionStringEnvironmentVariableName).
+        /// </summary>
+        public string StorageConnectionString { get; set; }
         public string[] ConfigurationKeys { get; set; }
         public bool PreFixConfigurationKeys { get; set; } = true;
     }

--- a/Configuration/SFA.DAS.Configuration.TestHarness/Program.cs
+++ b/Configuration/SFA.DAS.Configuration.TestHarness/Program.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Hosting;
+using SFA.DAS.Configuration.AzureTableStorage;
+
+namespace SFA.DAS.Configuration.TestHarness
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            using (var host = new HostBuilder()
+                .ConfigureAppConfiguration((c, b) => b
+                .AddAzureTableStorage(o =>
+                {
+                    o.EnvironmentNameEnvironmentVariableName = "";
+                    o.ConfigurationKeys = new[]
+                    {
+                        "DoesntExist"
+                    };
+                }))
+                .Build())
+            {
+            }
+        }
+    }
+}

--- a/Configuration/SFA.DAS.Configuration.TestHarness/SFA.DAS.Configuration.TestHarness.csproj
+++ b/Configuration/SFA.DAS.Configuration.TestHarness/SFA.DAS.Configuration.TestHarness.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\SFA.DAS.Configuration.AzureTableStorage\SFA.DAS.Configuration.AzureTableStorage.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/AzureTableStorageConfigurationProviderTests.cs
+++ b/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/AzureTableStorageConfigurationProviderTests.cs
@@ -13,8 +13,7 @@ using SFA.DAS.Testing;
 
 namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
 {
-    [TestFixture]
-    [Parallelizable]
+    [TestFixture, Parallelizable]
     public class AzureTableStorageConfigurationProviderTests : FluentTest<AzureTableStorageConfigurationProviderTestsFixture>
     {
         [Test, TestCaseSource(typeof(AzureTableStorageConfigurationProviderTestsSource), nameof(AzureTableStorageConfigurationProviderTestsSource.TestCasesWithPrefix))]
@@ -29,8 +28,6 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
             Test(f => f.SetConfigs(sourceConfigs, false), f => f.Load(), f => f.AssertData(expected));
         }
     }
-
-
 
     public class AzureTableStorageConfigurationProviderTestsSource
     {

--- a/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/AzureTableStorageConfigurationProviderTests.cs
+++ b/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/AzureTableStorageConfigurationProviderTests.cs
@@ -27,6 +27,12 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
         {
             Test(f => f.SetConfigs(sourceConfigs, false), f => f.Load(), f => f.AssertData(expected));
         }
+
+        [Test]
+        public void WhenReadingTablesAndConfigRowIsNotFound_ThenExceptionIsThrown()
+        {
+            TestException(f => f.ArrangeConfigNotFound(), f => f.Load(), (f, r) => r.Should().Throw<Exception>().WithMessage("Configuration row not found*"));
+        }
     }
 
     public class AzureTableStorageConfigurationProviderTestsSource
@@ -128,6 +134,15 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
             }
         }
 
+        public void ArrangeConfigNotFound()
+        {
+            const string configKey = "ConfigRowNotInTable";
+            ConfigProvider = new TestableAzureTableStorageConfigurationProvider(CloudStorageAccount.Object, EnvironmentName, new[] {configKey});
+
+            CloudTable.Setup(ct => ct.ExecuteAsync(It.Is<TableOperation>(to => to.Entity.RowKey == configKey)))
+                .ReturnsAsync(new TableResult { HttpStatusCode = 404 });
+        }
+        
         public void Load()
         {
             ConfigProvider.Load();

--- a/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBootstrapperTests.cs
+++ b/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBootstrapperTests.cs
@@ -7,8 +7,7 @@ using Fix = SFA.DAS.Configuration.UnitTests.AzureTableStorage.ConfigurationBoots
 
 namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
 {
-    [TestFixture]
-    [Parallelizable]
+    [TestFixture, Parallelizable]
     public class ConfigurationBootstrapperTests : FluentTest<ConfigurationBootstrapperTestsFixture>
     {
         [Test]

--- a/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBuilderExtensionsTests.cs
+++ b/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBuilderExtensionsTests.cs
@@ -15,11 +15,21 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
         {
             Test(f => f.AddAzureTableStorageWithOptions());
         }
-        
-        [Test, Ignore("WIP")]
-        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName_Then()
+
+        [Test]
+        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName_ThenAddCalledWithConfigurationSourceWithCorrectEnvironmentName()
         {
-            Test(f => f.AddAzureTableStorageWithOptions());
+            Test(f => f.ArrangeOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName(),
+                f => f.AddAzureTableStorageWithOptions(),
+                f => f.VerifyAddCalledWithConfigurationSourceWithCorrectEnvironmentName());
+        }
+        
+        [Test]
+        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithStorageConnectionStringEnvironmentVariableNameAndNoStorageConnectionString_ThenAddCalledWithConfigurationSourceWithCorrectConnectionString()
+        {
+            Test(f => f.ArrangeOptionsAreSuppliedWithStorageConnectionStringEnvironmentVariableNameAndNoStorageConnectionString(),
+                f => f.AddAzureTableStorageWithOptions(),
+                f => f.VerifyAddCalledWithConfigurationSourceWithCorrectConnectionString());
         }
     }
 
@@ -27,21 +37,77 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
     {
         public Mock<IConfigurationBuilder> ConfigurationBuilder { get; set; }
         public Action<StorageOptions> SetupOptions { get; set; }
+        public string[] ConfigurationKeys { get; set; }
+        public string ExpectedEnvironmentName { get; set; }
+        public const string EnvironmentNameFromVariable = nameof(EnvironmentNameFromVariable);
+        public string ExpectedConnectionString { get; set; }
+        public const string ConnectionStringFromVariable = nameof(ConnectionStringFromVariable);
         
         public ConfigurationBuilderExtensionsTestsFixture()
         {
             ConfigurationBuilder = new Mock<IConfigurationBuilder>();
-            SetupOptions = so => { };
+            ConfigurationKeys = new[] {"Key"};
+            SetupOptions = so => so.ConfigurationKeys = ConfigurationKeys;
+
+            // clear defaults, which are likely to be set on the developer's machine
+            Environment.SetEnvironmentVariable("APPSETTING_EnvironmentName", EnvironmentNameFromVariable);
+            Environment.SetEnvironmentVariable("APPSETTING_ConfigurationStorageConnectionString", ConnectionStringFromVariable);
         }
 
         public ConfigurationBuilderExtensionsTestsFixture ArrangeOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName()
         {
+            const string optionSuppliedEnvironmentNameEnvironmentVariableName = nameof(optionSuppliedEnvironmentNameEnvironmentVariableName);
+            
+            // this arrangement is actually the default, but we explicitly set it in case the defaults change
+            SetupOptions = so =>
+            {
+                so.ConfigurationKeys = ConfigurationKeys;
+                so.EnvironmentNameEnvironmentVariableName = optionSuppliedEnvironmentNameEnvironmentVariableName;
+                so.EnvironmentName = null;
+            };
+
+            // not here, just test
+            ExpectedEnvironmentName = "EnvironmentNameFromOptionSuppliedVariableName";
+            Environment.SetEnvironmentVariable(optionSuppliedEnvironmentNameEnvironmentVariableName, ExpectedEnvironmentName);
+            
             return this;
         }
-        
+
+        public ConfigurationBuilderExtensionsTestsFixture ArrangeOptionsAreSuppliedWithStorageConnectionStringEnvironmentVariableNameAndNoStorageConnectionString()
+        {
+            const string optionSuppliedStorageConnectionStringEnvironmentVariableName
+                = nameof(optionSuppliedStorageConnectionStringEnvironmentVariableName);
+            
+            // this arrangement is actually the default, but we explicitly set it in case the defaults change
+            SetupOptions = so =>
+            {
+                so.ConfigurationKeys = ConfigurationKeys;
+                so.StorageConnectionStringEnvironmentVariableName = optionSuppliedStorageConnectionStringEnvironmentVariableName;
+                so.StorageConnectionString = null;
+            };
+
+            // not here, just test
+            ExpectedConnectionString = "ConnectionStringFromOptionSuppliedVariableName";
+            Environment.SetEnvironmentVariable(optionSuppliedStorageConnectionStringEnvironmentVariableName, ExpectedConnectionString);
+            
+            return this;
+        }
+
         public void AddAzureTableStorageWithOptions()
         {
             ConfigurationBuilderExtensions.AddAzureTableStorage(ConfigurationBuilder.Object, SetupOptions);
+        }
+
+        public void VerifyAddCalledWithConfigurationSourceWithCorrectEnvironmentName()
+        {
+            ConfigurationBuilder.Verify(cb => cb.Add(It.Is<AzureTableStorageConfigurationSource>( 
+                s => s.EnvironmentName == ExpectedEnvironmentName)));
+        }
+        
+        public void VerifyAddCalledWithConfigurationSourceWithCorrectConnectionString()
+        {
+            ConfigurationBuilder.Verify(cb => cb.Add(It.Is<AzureTableStorageConfigurationSource>( 
+                s => s.ConnectionString == ExpectedConnectionString)));
         }
     }
 }

--- a/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBuilderExtensionsTests.cs
+++ b/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBuilderExtensionsTests.cs
@@ -1,0 +1,47 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Configuration.AzureTableStorage;
+using SFA.DAS.Testing;
+
+namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
+{
+    [TestFixture, Parallelizable]
+    public class ConfigurationBuilderExtensionsTests : FluentTest<ConfigurationBuilderExtensionsTestsFixture>
+    {
+        [Test, Ignore("WIP")]
+        public void AddAzureTableStorage_WhenSetupOptionsIsInvoked_ThenOptionsContainDefaults()
+        {
+            Test(f => f.AddAzureTableStorageWithOptions());
+        }
+        
+        [Test, Ignore("WIP")]
+        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName_Then()
+        {
+            Test(f => f.AddAzureTableStorageWithOptions());
+        }
+    }
+
+    public class ConfigurationBuilderExtensionsTestsFixture
+    {
+        public Mock<IConfigurationBuilder> ConfigurationBuilder { get; set; }
+        public Action<StorageOptions> SetupOptions { get; set; }
+        
+        public ConfigurationBuilderExtensionsTestsFixture()
+        {
+            ConfigurationBuilder = new Mock<IConfigurationBuilder>();
+            SetupOptions = so => { };
+        }
+
+        public ConfigurationBuilderExtensionsTestsFixture ArrangeOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName()
+        {
+            return this;
+        }
+        
+        public void AddAzureTableStorageWithOptions()
+        {
+            ConfigurationBuilderExtensions.AddAzureTableStorage(ConfigurationBuilder.Object, SetupOptions);
+        }
+    }
+}

--- a/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBuilderExtensionsTests.cs
+++ b/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBuilderExtensionsTests.cs
@@ -19,6 +19,18 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
                 f=> f.AssertOptionsContainDefaults());
         }
 
+//        [Test]
+//        public void AddAzureTableStorage_WhenDefaultEnvironmentNameOptionsAreUsedAndDefaultEnvironmentVariableIsPresent_ThenAddCalledWithConfigurationSourceWithEnvironmentNameFromDefaultEnvironmentVariable()
+//        {
+//            Test(f => f.AddAzureTableStorageWithOptions());
+//        }
+//
+//        [Test]
+//        public void AddAzureTableStorage_WhenDefaultEnvironmentNameOptionsAreUsedAndNoDefaultEnvironmentVariableIsPresent_ThenAddCalledWithConfigurationSourceWithEnvironmentNameAsDefault()
+//        {
+//            Test(f => f.AddAzureTableStorageWithOptions(), f=> f.AssertOptionsContainDefaults());
+//        }
+        
         [Test]
         public void AddAzureTableStorage_WhenOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName_ThenAddCalledWithConfigurationSourceWithEnvironmentNameFromGivenEnvironmentVariable()
         {
@@ -51,21 +63,21 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
                 f => f.VerifyAddCalledWithConfigurationSourceWithCorrectConnectionString());
         }
         
-//        [Test]
-//        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithStorageConnectionStringAndNoStorageConnectionStringEnvironmentVariableName_ThenAddCalledWithConfigurationSourceWithSuppliedStorageConnectionString()
-//        {
-//            Test(f => f.ArrangeOptionsAreSuppliedWithStorageConnectionStringAndNoStorageConnectionStringEnvironmentVariableName(),
-//                f => f.AddAzureTableStorageWithOptions(),
-//                f => f.VerifyAddCalledWithConfigurationSourceWithCorrectConnectionString());
-//        }
-//
-//        [Test]
-//        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithStorageConnectionStringAndStorageConnectionStringEnvironmentVariableName_ThenAddCalledWithConfigurationSourceWithSuppliedStorageConnectionString()
-//        {
-//            Test(f => f.ArrangeOptionsAreSuppliedWithStorageConnectionStringAndStorageConnectionStringEnvironmentVariableName(),
-//                f => f.AddAzureTableStorageWithOptions(),
-//                f => f.VerifyAddCalledWithConfigurationSourceWithCorrectConnectionString());
-//        }
+        [Test]
+        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithStorageConnectionStringAndNoStorageConnectionStringEnvironmentVariableName_ThenAddCalledWithConfigurationSourceWithSuppliedStorageConnectionString()
+        {
+            Test(f => f.ArrangeOptionsAreSuppliedWithStorageConnectionStringAndNoStorageConnectionStringEnvironmentVariableName(),
+                f => f.AddAzureTableStorageWithOptions(),
+                f => f.VerifyAddCalledWithConfigurationSourceWithCorrectConnectionString());
+        }
+
+        [Test]
+        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithStorageConnectionStringAndStorageConnectionStringEnvironmentVariableName_ThenAddCalledWithConfigurationSourceWithSuppliedStorageConnectionString()
+        {
+            Test(f => f.ArrangeOptionsAreSuppliedWithStorageConnectionStringAndStorageConnectionStringEnvironmentVariableName(),
+                f => f.AddAzureTableStorageWithOptions(),
+                f => f.VerifyAddCalledWithConfigurationSourceWithCorrectConnectionString());
+        }
     }
 
     public class ConfigurationBuilderExtensionsTestsFixture
@@ -77,11 +89,12 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
         public string ExpectedEnvironmentName { get; set; }
         public const string DirectlySuppliedEnvironmentName = nameof(DirectlySuppliedEnvironmentName);
         public const string EnvironmentNameFromVariable = nameof(EnvironmentNameFromVariable);
-        public const string optionSuppliedEnvironmentNameEnvironmentVariableName = nameof(optionSuppliedEnvironmentNameEnvironmentVariableName);
+        public const string OptionSuppliedEnvironmentNameEnvironmentVariableName = nameof(OptionSuppliedEnvironmentNameEnvironmentVariableName);
 
         public string ExpectedConnectionString { get; set; }
         public const string DirectlySuppliedConnectionString = nameof(DirectlySuppliedConnectionString);
         public const string ConnectionStringFromVariable = nameof(ConnectionStringFromVariable);
+        public const string OptionSuppliedConnectionStringEnvironmentVariableName = nameof(OptionSuppliedConnectionStringEnvironmentVariableName);
         
         public ConfigurationBuilderExtensionsTestsFixture()
         {
@@ -106,24 +119,21 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
         
         public ConfigurationBuilderExtensionsTestsFixture ArrangeOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName()
         {
-            // this arrangement is actually the default, but we explicitly set it in case the defaults change
             SetupOptions = so =>
             {
                 so.ConfigurationKeys = ConfigurationKeys;
-                so.EnvironmentNameEnvironmentVariableName = optionSuppliedEnvironmentNameEnvironmentVariableName;
+                so.EnvironmentNameEnvironmentVariableName = OptionSuppliedEnvironmentNameEnvironmentVariableName;
                 so.EnvironmentName = null;
             };
 
-            // not here, just test
             ExpectedEnvironmentName = "EnvironmentNameFromOptionSuppliedVariableName";
-            Environment.SetEnvironmentVariable(optionSuppliedEnvironmentNameEnvironmentVariableName, ExpectedEnvironmentName);
+            Environment.SetEnvironmentVariable(OptionSuppliedEnvironmentNameEnvironmentVariableName, ExpectedEnvironmentName);
             
             return this;
         }
 
         public ConfigurationBuilderExtensionsTestsFixture ArrangeOptionsAreSuppliedWithEnvironmentNameAndNoEnvironmentNameEnvironmentVariableName()
         {
-            // this arrangement is actually the default, but we explicitly set it in case the defaults change
             SetupOptions = so =>
             {
                 so.ConfigurationKeys = ConfigurationKeys;
@@ -136,17 +146,15 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
 
         public ConfigurationBuilderExtensionsTestsFixture ArrangeOptionsAreSuppliedWithEnvironmentNameAndEnvironmentNameEnvironmentVariableName()
         {
-            // this arrangement is actually the default, but we explicitly set it in case the defaults change
             SetupOptions = so =>
             {
                 so.ConfigurationKeys = ConfigurationKeys;
-                so.EnvironmentNameEnvironmentVariableName = optionSuppliedEnvironmentNameEnvironmentVariableName;
+                so.EnvironmentNameEnvironmentVariableName = OptionSuppliedEnvironmentNameEnvironmentVariableName;
                 so.EnvironmentName = ExpectedEnvironmentName = DirectlySuppliedEnvironmentName;
             };
 
-            // not here, just test
             ExpectedEnvironmentName = "EnvironmentNameFromOptionSuppliedVariableName";
-            Environment.SetEnvironmentVariable(optionSuppliedEnvironmentNameEnvironmentVariableName, ExpectedEnvironmentName);
+            Environment.SetEnvironmentVariable(OptionSuppliedEnvironmentNameEnvironmentVariableName, ExpectedEnvironmentName);
             
             return this;
         }
@@ -156,7 +164,6 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
             const string optionSuppliedStorageConnectionStringEnvironmentVariableName
                 = nameof(optionSuppliedStorageConnectionStringEnvironmentVariableName);
             
-            // this arrangement is actually the default, but we explicitly set it in case the defaults change
             SetupOptions = so =>
             {
                 so.ConfigurationKeys = ConfigurationKeys;
@@ -164,9 +171,35 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
                 so.StorageConnectionString = null;
             };
 
-            // not here, just test
             ExpectedConnectionString = "ConnectionStringFromOptionSuppliedVariableName";
             Environment.SetEnvironmentVariable(optionSuppliedStorageConnectionStringEnvironmentVariableName, ExpectedConnectionString);
+            
+            return this;
+        }
+        
+        public ConfigurationBuilderExtensionsTestsFixture ArrangeOptionsAreSuppliedWithStorageConnectionStringAndNoStorageConnectionStringEnvironmentVariableName()
+        {
+            SetupOptions = so =>
+            {
+                so.ConfigurationKeys = ConfigurationKeys;
+                so.StorageConnectionStringEnvironmentVariableName = null;
+                so.StorageConnectionString = ExpectedConnectionString = DirectlySuppliedConnectionString;
+            };
+
+            return this;
+        }
+
+        public ConfigurationBuilderExtensionsTestsFixture ArrangeOptionsAreSuppliedWithStorageConnectionStringAndStorageConnectionStringEnvironmentVariableName()
+        {
+            SetupOptions = so =>
+            {
+                so.ConfigurationKeys = ConfigurationKeys;
+                so.StorageConnectionStringEnvironmentVariableName = OptionSuppliedConnectionStringEnvironmentVariableName;
+                so.StorageConnectionString = ExpectedConnectionString = DirectlySuppliedConnectionString;
+            };
+
+            ExpectedEnvironmentName = "EnvironmentNameFromOptionSuppliedVariableName";
+            Environment.SetEnvironmentVariable(OptionSuppliedEnvironmentNameEnvironmentVariableName, ExpectedEnvironmentName);
             
             return this;
         }

--- a/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBuilderExtensionsTests.cs
+++ b/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBuilderExtensionsTests.cs
@@ -16,20 +16,22 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
         public void AddAzureTableStorage_WhenSetupOptionsIsInvoked_ThenOptionsContainDefaults()
         {
             Test(f => f.StoreCallbackOptions(), f => f.AddAzureTableStorageWithOptions(),
-                f=> f.AssertOptionsContainDefaults());
+                f => f.AssertOptionsContainDefaults());
         }
 
-//        [Test]
-//        public void AddAzureTableStorage_WhenDefaultEnvironmentNameOptionsAreUsedAndDefaultEnvironmentVariableIsPresent_ThenAddCalledWithConfigurationSourceWithEnvironmentNameFromDefaultEnvironmentVariable()
-//        {
-//            Test(f => f.AddAzureTableStorageWithOptions());
-//        }
-//
-//        [Test]
-//        public void AddAzureTableStorage_WhenDefaultEnvironmentNameOptionsAreUsedAndNoDefaultEnvironmentVariableIsPresent_ThenAddCalledWithConfigurationSourceWithEnvironmentNameAsDefault()
-//        {
-//            Test(f => f.AddAzureTableStorageWithOptions(), f=> f.AssertOptionsContainDefaults());
-//        }
+        [Test]
+        public void AddAzureTableStorage_WhenDefaultEnvironmentNameOptionsAreUsedAndDefaultEnvironmentVariableIsPresent_ThenAddCalledWithConfigurationSourceWithEnvironmentNameFromDefaultEnvironmentVariable()
+        {
+            Test(f => f.ArrangeDefaultEnvironmentNameVariable(), f => f.AddAzureTableStorageWithOptions(),
+                f => f.VerifyAddCalledWithConfigurationSourceWithCorrectEnvironmentName());
+        }
+
+        [Test]
+        public void AddAzureTableStorage_WhenDefaultEnvironmentNameOptionsAreUsedAndNoDefaultEnvironmentVariableIsPresent_ThenAddCalledWithConfigurationSourceWithEnvironmentNameAsDefault()
+        {
+            Test(f => f.ArrangeNoDefaultEnvironmentNameVariable(), f => f.AddAzureTableStorageWithOptions(),
+                    f => f.VerifyAddCalledWithConfigurationSourceWithCorrectEnvironmentName());
+        }
         
         [Test]
         public void AddAzureTableStorage_WhenOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName_ThenAddCalledWithConfigurationSourceWithEnvironmentNameFromGivenEnvironmentVariable()
@@ -90,7 +92,8 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
         public const string DirectlySuppliedEnvironmentName = nameof(DirectlySuppliedEnvironmentName);
         public const string EnvironmentNameFromVariable = nameof(EnvironmentNameFromVariable);
         public const string OptionSuppliedEnvironmentNameEnvironmentVariableName = nameof(OptionSuppliedEnvironmentNameEnvironmentVariableName);
-
+        public const string EnvironmentNameFromDefaultEnvironmentVariable = nameof(EnvironmentNameFromDefaultEnvironmentVariable);
+        
         public string ExpectedConnectionString { get; set; }
         public const string DirectlySuppliedConnectionString = nameof(DirectlySuppliedConnectionString);
         public const string ConnectionStringFromVariable = nameof(ConnectionStringFromVariable);
@@ -114,6 +117,20 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
                 StoredCallbackOptions = so.Clone();
                 so.ConfigurationKeys = ConfigurationKeys;
             };
+            return this;
+        }
+
+        public ConfigurationBuilderExtensionsTestsFixture ArrangeDefaultEnvironmentNameVariable()
+        {
+            ExpectedEnvironmentName = EnvironmentNameFromDefaultEnvironmentVariable;
+            Environment.SetEnvironmentVariable("APPSETTING_EnvironmentName", ExpectedEnvironmentName);
+            return this;
+        }
+
+        public ConfigurationBuilderExtensionsTestsFixture ArrangeNoDefaultEnvironmentNameVariable()
+        {
+            ExpectedEnvironmentName = "LOCAL";
+            Environment.SetEnvironmentVariable("APPSETTING_EnvironmentName", null);
             return this;
         }
         

--- a/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBuilderExtensionsTests.cs
+++ b/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBuilderExtensionsTests.cs
@@ -11,7 +11,6 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
     [TestFixture]
     public class ConfigurationBuilderExtensionsTests : FluentTest<ConfigurationBuilderExtensionsTestsFixture>
     {
-        //todo: rename tests names to be shorter
         [Test]
         public void AddAzureTableStorage_WhenSetupOptionsIsInvoked_ThenOptionsContainDefaults()
         {

--- a/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBuilderExtensionsTests.cs
+++ b/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/ConfigurationBuilderExtensionsTests.cs
@@ -11,6 +11,7 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
     [TestFixture]
     public class ConfigurationBuilderExtensionsTests : FluentTest<ConfigurationBuilderExtensionsTestsFixture>
     {
+        //todo: rename tests names to be shorter
         [Test]
         public void AddAzureTableStorage_WhenSetupOptionsIsInvoked_ThenOptionsContainDefaults()
         {
@@ -19,20 +20,52 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
         }
 
         [Test]
-        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName_ThenAddCalledWithConfigurationSourceWithCorrectEnvironmentName()
+        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName_ThenAddCalledWithConfigurationSourceWithEnvironmentNameFromGivenEnvironmentVariable()
         {
             Test(f => f.ArrangeOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName(),
                 f => f.AddAzureTableStorageWithOptions(),
                 f => f.VerifyAddCalledWithConfigurationSourceWithCorrectEnvironmentName());
         }
+
+        [Test]
+        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithEnvironmentNameAndNoEnvironmentNameEnvironmentVariableName_ThenAddCalledWithConfigurationSourceWithSuppliedEnvironmentName()
+        {
+            Test(f => f.ArrangeOptionsAreSuppliedWithEnvironmentNameAndNoEnvironmentNameEnvironmentVariableName(),
+                f => f.AddAzureTableStorageWithOptions(),
+                f => f.VerifyAddCalledWithConfigurationSourceWithCorrectEnvironmentName());
+        }
+
+        [Test]
+        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithEnvironmentNameAndEnvironmentNameEnvironmentVariableName_ThenAddCalledWithConfigurationSourceWithSuppliedEnvironmentName()
+        {
+            Test(f => f.ArrangeOptionsAreSuppliedWithEnvironmentNameAndEnvironmentNameEnvironmentVariableName(),
+                f => f.AddAzureTableStorageWithOptions(),
+                f => f.VerifyAddCalledWithConfigurationSourceWithCorrectEnvironmentName());
+        }
         
         [Test]
-        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithStorageConnectionStringEnvironmentVariableNameAndNoStorageConnectionString_ThenAddCalledWithConfigurationSourceWithCorrectConnectionString()
+        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithStorageConnectionStringEnvironmentVariableNameAndNoStorageConnectionString_ThenAddCalledWithConfigurationSourceWithStorageConnectionStringFromGivenEnvironmentVariable()
         {
             Test(f => f.ArrangeOptionsAreSuppliedWithStorageConnectionStringEnvironmentVariableNameAndNoStorageConnectionString(),
                 f => f.AddAzureTableStorageWithOptions(),
                 f => f.VerifyAddCalledWithConfigurationSourceWithCorrectConnectionString());
         }
+        
+//        [Test]
+//        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithStorageConnectionStringAndNoStorageConnectionStringEnvironmentVariableName_ThenAddCalledWithConfigurationSourceWithSuppliedStorageConnectionString()
+//        {
+//            Test(f => f.ArrangeOptionsAreSuppliedWithStorageConnectionStringAndNoStorageConnectionStringEnvironmentVariableName(),
+//                f => f.AddAzureTableStorageWithOptions(),
+//                f => f.VerifyAddCalledWithConfigurationSourceWithCorrectConnectionString());
+//        }
+//
+//        [Test]
+//        public void AddAzureTableStorage_WhenOptionsAreSuppliedWithStorageConnectionStringAndStorageConnectionStringEnvironmentVariableName_ThenAddCalledWithConfigurationSourceWithSuppliedStorageConnectionString()
+//        {
+//            Test(f => f.ArrangeOptionsAreSuppliedWithStorageConnectionStringAndStorageConnectionStringEnvironmentVariableName(),
+//                f => f.AddAzureTableStorageWithOptions(),
+//                f => f.VerifyAddCalledWithConfigurationSourceWithCorrectConnectionString());
+//        }
     }
 
     public class ConfigurationBuilderExtensionsTestsFixture
@@ -42,8 +75,12 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
         public StorageOptions StoredCallbackOptions { get; set; }
         public string[] ConfigurationKeys { get; set; }
         public string ExpectedEnvironmentName { get; set; }
+        public const string DirectlySuppliedEnvironmentName = nameof(DirectlySuppliedEnvironmentName);
         public const string EnvironmentNameFromVariable = nameof(EnvironmentNameFromVariable);
+        public const string optionSuppliedEnvironmentNameEnvironmentVariableName = nameof(optionSuppliedEnvironmentNameEnvironmentVariableName);
+
         public string ExpectedConnectionString { get; set; }
+        public const string DirectlySuppliedConnectionString = nameof(DirectlySuppliedConnectionString);
         public const string ConnectionStringFromVariable = nameof(ConnectionStringFromVariable);
         
         public ConfigurationBuilderExtensionsTestsFixture()
@@ -69,8 +106,6 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
         
         public ConfigurationBuilderExtensionsTestsFixture ArrangeOptionsAreSuppliedWithEnvironmentNameEnvironmentVariableNameAndNoEnvironmentName()
         {
-            const string optionSuppliedEnvironmentNameEnvironmentVariableName = nameof(optionSuppliedEnvironmentNameEnvironmentVariableName);
-            
             // this arrangement is actually the default, but we explicitly set it in case the defaults change
             SetupOptions = so =>
             {
@@ -86,6 +121,36 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
             return this;
         }
 
+        public ConfigurationBuilderExtensionsTestsFixture ArrangeOptionsAreSuppliedWithEnvironmentNameAndNoEnvironmentNameEnvironmentVariableName()
+        {
+            // this arrangement is actually the default, but we explicitly set it in case the defaults change
+            SetupOptions = so =>
+            {
+                so.ConfigurationKeys = ConfigurationKeys;
+                so.EnvironmentNameEnvironmentVariableName = null;
+                so.EnvironmentName = ExpectedEnvironmentName = DirectlySuppliedEnvironmentName;
+            };
+
+            return this;
+        }
+
+        public ConfigurationBuilderExtensionsTestsFixture ArrangeOptionsAreSuppliedWithEnvironmentNameAndEnvironmentNameEnvironmentVariableName()
+        {
+            // this arrangement is actually the default, but we explicitly set it in case the defaults change
+            SetupOptions = so =>
+            {
+                so.ConfigurationKeys = ConfigurationKeys;
+                so.EnvironmentNameEnvironmentVariableName = optionSuppliedEnvironmentNameEnvironmentVariableName;
+                so.EnvironmentName = ExpectedEnvironmentName = DirectlySuppliedEnvironmentName;
+            };
+
+            // not here, just test
+            ExpectedEnvironmentName = "EnvironmentNameFromOptionSuppliedVariableName";
+            Environment.SetEnvironmentVariable(optionSuppliedEnvironmentNameEnvironmentVariableName, ExpectedEnvironmentName);
+            
+            return this;
+        }
+        
         public ConfigurationBuilderExtensionsTestsFixture ArrangeOptionsAreSuppliedWithStorageConnectionStringEnvironmentVariableNameAndNoStorageConnectionString()
         {
             const string optionSuppliedStorageConnectionStringEnvironmentVariableName

--- a/Configuration/SFA.DAS.Configuration.UnitTests/TestHelpers.cs
+++ b/Configuration/SFA.DAS.Configuration.UnitTests/TestHelpers.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+
+namespace SFA.DAS.Configuration.UnitTests
+{
+    public static class TestHelpers
+    {
+        public static T Clone<T>(this T source)
+        {
+            if (ReferenceEquals(source, null)) return default;
+
+            var deserializeSettings = new JsonSerializerSettings { ObjectCreationHandling = ObjectCreationHandling.Replace };
+            return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(source), deserializeSettings);
+        }
+    }
+}

--- a/Configuration/SFA.DAS.Configuration.sln
+++ b/Configuration/SFA.DAS.Configuration.sln
@@ -18,6 +18,8 @@ ProjectSection(SolutionItems) = preProject
 	..\README.md = ..\README.md
 EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.Configuration.TestHarness", "SFA.DAS.Configuration.TestHarness\SFA.DAS.Configuration.TestHarness.csproj", "{BA29A4D8-F631-4CDC-9B99-D3B5618EA320}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,12 +38,17 @@ Global
 		{81BDDA54-55F6-4694-A474-31BBD30F3EF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81BDDA54-55F6-4694-A474-31BBD30F3EF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81BDDA54-55F6-4694-A474-31BBD30F3EF6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA29A4D8-F631-4CDC-9B99-D3B5618EA320}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA29A4D8-F631-4CDC-9B99-D3B5618EA320}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA29A4D8-F631-4CDC-9B99-D3B5618EA320}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA29A4D8-F631-4CDC-9B99-D3B5618EA320}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{DCAE686F-CD1B-4534-A735-C478BE92E1FF} = {A71A2CA0-779F-4F53-A5FE-01CBB8DCA6ED}
+		{BA29A4D8-F631-4CDC-9B99-D3B5618EA320} = {A71A2CA0-779F-4F53-A5FE-01CBB8DCA6ED}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D561EBDF-4F4A-4946-8FCA-81DCCFC7FEFC}


### PR DESCRIPTION
Add option to directly pass StorageConnectionString & EnvironmentName.
Also, throw useful message if config row not present & populate options with defaults before calling back to consumer.