### PR TITLE
Revert "Removed .NET Framework specific Azure Service Bus configuration"

### DIFF
--- a/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus/AzureServiceBus/EndpointConfigurationExtensions.cs
+++ b/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus/AzureServiceBus/EndpointConfigurationExtensions.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using NServiceBus;
+#if NET462
+using NServiceBus.Transport.AzureServiceBus;
+#endif
 
 namespace SFA.DAS.NServiceBus.AzureServiceBus
 {
@@ -7,14 +10,42 @@ namespace SFA.DAS.NServiceBus.AzureServiceBus
     {
         public static EndpointConfiguration UseAzureServiceBusTransport(this EndpointConfiguration config, string connectionString, Action<RoutingSettings> routing = null)
         {
-            var transport = config.UseTransport<AzureServiceBusTransport>();
-            var ruleNameShortener = new RuleNameShortener();
+#if NETSTANDARD2_0
+                var transport = config.UseTransport<AzureServiceBusTransport>();
+                var ruleNameShortener = new RuleNameShortener();
 
-            transport.ConnectionString(connectionString);
-            transport.RuleNameShortener(ruleNameShortener.Shorten);
-            transport.Transactions(TransportTransactionMode.ReceiveOnly);
+                transport.ConnectionString(connectionString);
+                transport.RuleNameShortener(ruleNameShortener.Shorten);
+                transport.Transactions(TransportTransactionMode.ReceiveOnly);
 
-            routing?.Invoke(transport.Routing());
+                routing?.Invoke(transport.Routing());
+#elif NET462
+                var transport = config.UseTransport<AzureServiceBusTransport>();
+
+                transport.BrokeredMessageBodyType(SupportedBrokeredMessageBodyTypes.Stream);
+                transport.ConnectionString(connectionString);
+                transport.Transactions(TransportTransactionMode.ReceiveOnly);
+                transport.UseForwardingTopology();
+
+                var messageReceivers = transport.MessageReceivers();
+
+                messageReceivers.AutoRenewTimeout(TimeSpan.FromMinutes(10));
+
+                var queues = transport.Queues();
+
+                queues.ForwardDeadLetteredMessagesTo(q => q != "error" && q != "audit" && q != "deadletter", "deadletter");
+                queues.LockDuration(TimeSpan.FromMinutes(1));
+
+                var subscriptions = transport.Subscriptions();
+
+                subscriptions.ForwardDeadLetteredMessagesTo("deadletters");
+
+                var sanitization = transport.Sanitization();
+
+                sanitization.UseStrategy<ValidateAndHashIfNeeded>();
+
+                routing?.Invoke(transport.Routing());
+#endif
 
             return config;
         }

--- a/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus.csproj
+++ b/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         
         <Authors>DAS</Authors>
@@ -28,8 +28,15 @@
         <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.1.0" />
         <PackageReference Include="NServiceBus.NLog" Version="3.0.0" />
         <PackageReference Include="NServiceBus.StructureMap" Version="7.0.0" />
-        <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.0.0" />
         <PackageReference Include="StructureMap" Version="4.6.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="1.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+        <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureServiceBus" Version="8.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Revert "Removed .NET Framework specific Azure Service Bus configuration" to prevent legacy .NET Framework consumers having to upgrade their Microsoft.IdentityModel.Clients.ActiveDirectory package right now

This reverts commit fc9720c0ac32d2b5e12f1bef92446c9ea0d5a775.