### PR TITLE
Now uses project references rather than nugets to aid in version matching

### DIFF
--- a/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus.AzureFunction.UnitTests/SFA.DAS.NServiceBus.AzureFunction.UnitTests.csproj
+++ b/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus.AzureFunction.UnitTests/SFA.DAS.NServiceBus.AzureFunction.UnitTests.csproj
@@ -8,7 +8,7 @@
     
     <ItemGroup>
         <PackageReference Include="nunit" Version="3.10.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
         <PackageReference Include="Moq" Version="4.10.1" />
         <PackageReference Include="NServiceBus" Version="7.1.7" />

--- a/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus.AzureFunction/Hosting/NServiceBusListener.cs
+++ b/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus.AzureFunction/Hosting/NServiceBusListener.cs
@@ -9,7 +9,7 @@ using NServiceBus.Raw;
 using NServiceBus.Transport;
 using SFA.DAS.NServiceBus.AzureFunction.Attributes;
 using SFA.DAS.NServiceBus.AzureFunction.Configuration;
-using SFA.DAS.NServiceBus.AzureServiceBus;
+using SFA.DAS.NServiceBus.Configuration.AzureServiceBus;
 
 namespace SFA.DAS.NServiceBus.AzureFunction.Hosting
 {

--- a/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus.AzureFunction/SFA.DAS.NServiceBus.AzureFunction.csproj
+++ b/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus.AzureFunction/SFA.DAS.NServiceBus.AzureFunction.csproj
@@ -25,4 +25,8 @@
         <PackageReference Include="SFA.DAS.NServiceBus" Version="11.0.2" />
     </ItemGroup>
     
+    <ItemGroup>
+      <ProjectReference Include="..\SFA.DAS.NServiceBus\SFA.DAS.NServiceBus.csproj" />
+    </ItemGroup>
+    
 </Project>

--- a/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus.SqlServer.UnitTests/SFA.DAS.NServiceBus.SqlServer.UnitTests.csproj
+++ b/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus.SqlServer.UnitTests/SFA.DAS.NServiceBus.SqlServer.UnitTests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Moq" Version="4.10.0" />
         <PackageReference Include="NServiceBus.Testing" Version="7.0.0" />
         <PackageReference Include="NUnit" Version="3.10.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
         <PackageReference Include="SFA.DAS.Testing" Version="3.0.161" />
     </ItemGroup>
     

--- a/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus.UnitTests/SFA.DAS.NServiceBus.UnitTests.csproj
+++ b/SFA.DAS.NServiceBus/SFA.DAS.NServiceBus.UnitTests/SFA.DAS.NServiceBus.UnitTests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Moq" Version="4.10.0" />
         <PackageReference Include="NServiceBus.Testing" Version="7.0.0" />
         <PackageReference Include="NUnit" Version="3.10.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
         <PackageReference Include="SFA.DAS.Testing" Version="3.0.161" />
     </ItemGroup>
     


### PR DESCRIPTION
I've found issues with using the same version of the SFA.DAS.NServiceBus nuget with the SFA.DAS.NServiceBus.AzureFunction nuget. The problem was that the azure function nuget referenced a nuget version of the NServiceBus package which was different to the version it one even though it was in the same solution. It makes sense to keep these two nugets in sync version wise so have now changed it to a project reference. Adding reviewers that i think may be interested in this change