### PR TITLE
Implement real token generation

### DIFF
--- a/SFA.DAS.Http/SFA.DAS.Http/Configuration/IJwtClientConfiguration.cs
+++ b/SFA.DAS.Http/SFA.DAS.Http/Configuration/IJwtClientConfiguration.cs
@@ -3,6 +3,9 @@
     public interface IJwtClientConfiguration
     {
         // JWT Configuration
-        string ClientToken { get; }
+        string Issuer {get; }
+        string Audience {get; }
+        string ClientSecret {get; }
+        int TokenExpirySeconds {get; }
     }
 }

--- a/SFA.DAS.Http/SFA.DAS.Http/Configuration/IStaticJwtClientConfiguration.cs
+++ b/SFA.DAS.Http/SFA.DAS.Http/Configuration/IStaticJwtClientConfiguration.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.Http.Configuration
+{
+    public interface IStaticJwtClientConfiguration
+    {
+        // JWT Configuration
+        string ClientToken { get; }
+    }
+}

--- a/SFA.DAS.Http/SFA.DAS.Http/SFA.DAS.Http.csproj
+++ b/SFA.DAS.Http/SFA.DAS.Http/SFA.DAS.Http.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.8" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>

--- a/SFA.DAS.Http/SFA.DAS.Http/TokenGenerators/JwtBearerTokenGenerator.cs
+++ b/SFA.DAS.Http/SFA.DAS.Http/TokenGenerators/JwtBearerTokenGenerator.cs
@@ -1,20 +1,39 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
+using System.Text;
 using SFA.DAS.Http.Configuration;
+using System;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
 
 namespace SFA.DAS.Http.TokenGenerators
 {
     public class JwtBearerTokenGenerator : IGenerateBearerToken
     {
-        private readonly string _jwtToken;
+        private readonly IJwtClientConfiguration _config;
 
         public JwtBearerTokenGenerator(IJwtClientConfiguration configuration)
         {
-            _jwtToken = configuration.ClientToken;
+            _config = configuration;
         }
 
-        public Task<string> Generate()
+        public async Task<string> Generate()
         {
-            return Task.FromResult(_jwtToken);
+            var handler = new JwtSecurityTokenHandler();
+            var signingSecret = Encoding.UTF8.GetBytes(_config.ClientSecret);
+            var securitytokenDescriptor = new SecurityTokenDescriptor
+            {
+                Issuer = _config.Issuer,
+                Audience = _config.Audience,
+                Expires = DateTime.UtcNow.AddSeconds(_config.TokenExpirySeconds),
+                SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(signingSecret), SecurityAlgorithms.HmacSha256Signature)
+            };
+
+            var token = handler.CreateToken(securitytokenDescriptor);
+
+            return await Task.Run(() =>
+            {
+                return handler.WriteToken(token);
+            });
         }
     }
 }

--- a/SFA.DAS.Http/SFA.DAS.Http/TokenGenerators/StaticJwtBearerTokenGenerator.cs
+++ b/SFA.DAS.Http/SFA.DAS.Http/TokenGenerators/StaticJwtBearerTokenGenerator.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using SFA.DAS.Http.Configuration;
+
+namespace SFA.DAS.Http.TokenGenerators
+{
+    public class StaticJwtBearerTokenGenerator : IGenerateBearerToken
+    {
+        private readonly string _jwtToken;
+
+        public StaticJwtBearerTokenGenerator(IStaticJwtClientConfiguration configuration)
+        {
+            _jwtToken = configuration.ClientToken;
+        }
+
+        public Task<string> Generate()
+        {
+            return Task.FromResult(_jwtToken);
+        }
+    }
+}


### PR DESCRIPTION
This PR replaces the existing `JwtTokenGenerator` class with one that actually generates JWT tokens.

The original implementation has been renamed to `StaticJwtGenerator`

Example implementation:

```
    class Program
    {

        public class JwtClientConfiguration : IJwtClientConfiguration
        {
            public string Issuer {get; set;}
            public string Audience {get; set;}
            public string ClientSecret {get; set;}
            public int TokenExpirySeconds {get; set;}
        }

        static void Main(string[] args)
        {
            var config = new JwtClientConfiguration
                {
                    Issuer = "xxx",
                    Audience = "xxx",
                    ClientSecret = "xxx",
                    TokenExpirySeconds = 500,
                };


            var gen = new JwtBearerTokenGenerator(config);
            var tok = gen.Generate();
            Console.WriteLine(tok.Result);
        }
    }
```