### PR TITLE
QUAL-408 enable paging in live vacancies

### DIFF
--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/ClientTests/GetVacancyTests.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/ClientTests/GetVacancyTests.cs
@@ -1,15 +1,16 @@
-﻿using NUnit.Framework;
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
 
 namespace SFA.DAS.Recruit.Vacancies.Client.UnitTests.ClientTests
 {
     [TestFixture]
     public class GetVacancyTests
     {
+        private readonly string connectionString = "mongodb://localhost:C2y6yDjf5%2FR%2Bob0N8A7Cgv30VRDJIWEHLM%2B4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw%2FJw%3D%3D@localhost:10255/admin?ssl=true";
         [Ignore("A helper test to get vacancy")]
         [Test]
         public void ShouldGetVacancyFromLiveOrClosedView()
         {
-            var connectionString = string.Empty;
             var sut = new Client(connectionString, "recruit", "queryStore", null);
 
             var vacancyReference = 1000000022;
@@ -22,7 +23,6 @@ namespace SFA.DAS.Recruit.Vacancies.Client.UnitTests.ClientTests
         [Test]
         public void ShouldGetVacancyFromLiveView()
         {
-            var connectionString = string.Empty;
             var sut = new Client(connectionString, "recruit", "queryStore", null);
 
             var vacancyReference = 1000005528;
@@ -30,5 +30,27 @@ namespace SFA.DAS.Recruit.Vacancies.Client.UnitTests.ClientTests
 
             Assert.AreEqual(vacancyReference, vac.VacancyReference);
         }
+
+        [Ignore("A helper test to get all live vacancies in pages")]
+        [Test]
+        public async Task ShouldGetPagedVacancies()
+        {
+            var sut = new Client(connectionString, "recruit", "queryStore", null);
+
+            var count = await sut.GetLiveVacanciesCount();
+
+            var pages = (count / 4) + 1;
+            var i = 0;
+            var retrievedCount = 0;
+            while(i < pages)
+            {
+                i++;
+                var vac = await sut.GetLiveVacancies(4,i);
+                retrievedCount += vac.Count;
+            }
+
+            Assert.AreEqual(count, retrievedCount);
+        }
+
     }
 }

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/ClientTests/GetVacancyTests.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/ClientTests/GetVacancyTests.cs
@@ -45,7 +45,7 @@ namespace SFA.DAS.Recruit.Vacancies.Client.UnitTests.ClientTests
             while(i < pages)
             {
                 i++;
-                var vac = await sut.GetLiveVacancies(4,i);
+                var vac = await sut.GetLiveVacanciesAsync(4,i);
                 retrievedCount += vac.Count;
             }
 

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/ClientTests/GetVacancyTests.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client.UnitTests/ClientTests/GetVacancyTests.cs
@@ -37,7 +37,7 @@ namespace SFA.DAS.Recruit.Vacancies.Client.UnitTests.ClientTests
         {
             var sut = new Client(connectionString, "recruit", "queryStore", null);
 
-            var count = await sut.GetLiveVacanciesCount();
+            var count = await sut.GetLiveVacanciesCountAsync();
 
             var pages = (count / 4) + 1;
             var i = 0;

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Client.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Client.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Authentication;
+using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Queue;
 using MongoDB.Bson.Serialization.Conventions;
@@ -67,6 +68,27 @@ namespace SFA.DAS.Recruit.Vacancies.Client
                             .AsQueryable()
                             .Where(each => each.ViewType.Equals(LiveVacancyDocumentType))
                             .ToList();
+            return vacancies;
+        }
+
+        public Task<List<Vacancy>> GetLiveVacancies(int pageSize, int pageNumber)
+        {
+            var skip =  (((pageNumber < 1 ? 1 : pageNumber) - 1) * pageSize);
+            var collection = GetCollection();
+            var vacancies = collection
+                            .AsQueryable()
+                            .Where(each => each.ViewType.Equals(LiveVacancyDocumentType))
+                            .Skip(skip)
+                            .Take(pageSize)
+                            .ToListAsync();
+            return vacancies;
+        }
+
+        public Task<long> GetLiveVacanciesCount()
+        {
+            var collection = GetCollection();
+            var vacancies = collection
+                            .CountDocumentsAsync(vacancy => vacancy.ViewType.Equals(LiveVacancyDocumentType));
             return vacancies;
         }
 

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Client.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Client.cs
@@ -71,7 +71,7 @@ namespace SFA.DAS.Recruit.Vacancies.Client
             return vacancies;
         }
 
-        public Task<List<Vacancy>> GetLiveVacancies(int pageSize, int pageNumber)
+        public Task<List<Vacancy>> GetLiveVacanciesAsync(int pageSize, int pageNumber)
         {
             var skip =  (((pageNumber < 1 ? 1 : pageNumber) - 1) * pageSize);
             var collection = GetCollection();

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Client.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/Client.cs
@@ -84,12 +84,11 @@ namespace SFA.DAS.Recruit.Vacancies.Client
             return vacancies;
         }
 
-        public Task<long> GetLiveVacanciesCount()
+        public Task<long> GetLiveVacanciesCountAsync()
         {
             var collection = GetCollection();
-            var vacancies = collection
-                            .CountDocumentsAsync(vacancy => vacancy.ViewType.Equals(LiveVacancyDocumentType));
-            return vacancies;
+            return collection
+                .CountDocumentsAsync(vacancy => vacancy.ViewType.Equals(LiveVacancyDocumentType));
         }
 
         public void SubmitApplication(Application application)

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/IClient.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/IClient.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.Recruit.Vacancies.Client
         Vacancy GetPublishedVacancy(long vacancyReference);
         IList<Vacancy> GetLiveVacancies();
         Task<List<Vacancy>> GetLiveVacanciesAsync(int pageSize, int pageNumber);
-        Task<long> GetLiveVacanciesCount();
+        Task<long> GetLiveVacanciesCountAsync();
         void SubmitApplication(Application application);
         void WithdrawApplication(long vacancyReference, Guid candidateId);
         void DeleteCandidate(Guid candidateId);

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/IClient.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/IClient.cs
@@ -10,6 +10,7 @@ namespace SFA.DAS.Recruit.Vacancies.Client
         Vacancy GetPublishedVacancy(long vacancyReference);
         IList<Vacancy> GetLiveVacancies();
         Task<List<Vacancy>> GetLiveVacanciesAsync(int pageSize, int pageNumber);
+        Task<long> GetLiveVacanciesCount();
         void SubmitApplication(Application application);
         void WithdrawApplication(long vacancyReference, Guid candidateId);
         void DeleteCandidate(Guid candidateId);

--- a/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/IClient.cs
+++ b/SFA.DAS.Recruit.Vacancies.Client/SFA.DAS.Recruit.Vacancies.Client/IClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using SFA.DAS.Recruit.Vacancies.Client.Entities;
 
 namespace SFA.DAS.Recruit.Vacancies.Client
@@ -8,6 +9,7 @@ namespace SFA.DAS.Recruit.Vacancies.Client
     {
         Vacancy GetPublishedVacancy(long vacancyReference);
         IList<Vacancy> GetLiveVacancies();
+        Task<List<Vacancy>> GetLiveVacanciesAsync(int pageSize, int pageNumber);
         void SubmitApplication(Application application);
         void WithdrawApplication(long vacancyReference, Guid candidateId);
         void DeleteCandidate(Guid candidateId);


### PR DESCRIPTION
FAA was querying all the live vacancies without any batching process. Now that the live vacancies are adding up, we need to allow FAA to batch process it. Added two methods to allow batching, one to get live vacancy count and other to retrieve live vacancy in batches. 