### PR TITLE
Con 1977 content change for create an advert journey

### DIFF
--- a/VacancyServices.Wage/SFA.DAS.VacancyServices.Wage.UnitTests/WagePresenterTests.cs
+++ b/VacancyServices.Wage/SFA.DAS.VacancyServices.Wage.UnitTests/WagePresenterTests.cs
@@ -54,8 +54,8 @@ namespace SFA.DAS.VacancyServices.Wage.UnitTests
             actual.Should().Be(expected);
         }
 
-        [TestCase(WageUnit.Weekly, "£150.00 - £270.00" + Space + WageConstants.PerWeekText)]
-        [TestCase(WageUnit.Annually, "£7,800.00 - £14,040.00" + Space + WageConstants.PerYearText)]
+        [TestCase(WageUnit.Weekly, "£150.00 to £270.00" + Space + WageConstants.PerWeekText)]
+        [TestCase(WageUnit.Annually, "£7,800.00 to £14,040.00" + Space + WageConstants.PerYearText)]
         public void ShouldGetDisplayAmountWithFrequencyPostfixNationalMinimums_After1stOct2016(WageUnit unit, string expected)
         {
             // Act.

--- a/VacancyServices.Wage/SFA.DAS.VacancyServices.Wage/WagePresenter.cs
+++ b/VacancyServices.Wage/SFA.DAS.VacancyServices.Wage/WagePresenter.cs
@@ -111,7 +111,7 @@ namespace SFA.DAS.VacancyServices.Wage
             string lowerRange = FormatWageAmount(wageRange.Under18NationalMinimumWage * hoursPerWeek);
             string higherRange = FormatWageAmount(wageRange.Over25NationalMinimumWage * hoursPerWeek);
 
-            return $"{lowerRange} - {higherRange}";
+            return $"{lowerRange} to {higherRange}";
         }
 
         private static string GetYearlyNationalMinimumWage(decimal hoursPerWeek, DateTime possibleStartDate)

--- a/VacancyServices.Wage/SFA.DAS.VacancyServices.Wage/WagePresenter.cs
+++ b/VacancyServices.Wage/SFA.DAS.VacancyServices.Wage/WagePresenter.cs
@@ -123,7 +123,7 @@ namespace SFA.DAS.VacancyServices.Wage
             string higherRange =
                 FormatWageAmount(WageCalculator.GetYearlyRateFromHourlyRate(wageRange.Over25NationalMinimumWage, hoursPerWeek));
 
-            return $"{lowerRange} - {higherRange}";
+            return $"{lowerRange} to {higherRange}";
         }
 
         private static string FormatWageAmount(decimal? wageAmount)


### PR DESCRIPTION
Updated the VacancyService.Wage package to return a minimum salary range string with 'to' instead of '-'