### PR TITLE
AEDB-45 provider shared UI

### DIFF
--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI.Tests/Extensions/WhenConstructingTheExternalUrl.cs
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI.Tests/Extensions/WhenConstructingTheExternalUrl.cs
@@ -1,0 +1,139 @@
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Provider.Shared.UI.Extensions;
+using SFA.DAS.Provider.Shared.UI.Models;
+
+namespace SFA.DAS.Provider.Shared.UI.Tests.Extensions
+{
+    [Parallelizable]
+    public class WhenConstructingTheExternalUrl
+    {
+        private Mock<IOptions<ProviderSharedUIConfiguration>> _sharedUiConfiguration;
+        private ExternalUrlHelper _helper;
+
+        [SetUp]
+        public void Arrange()
+        {
+            var config = new ProviderSharedUIConfiguration
+            {
+                DashboardUrl = "https://test.local"
+            };
+            _sharedUiConfiguration = new Mock<IOptions<ProviderSharedUIConfiguration>>();
+            _sharedUiConfiguration.Setup(x => x.Value).Returns(config);
+            _helper = new ExternalUrlHelper(_sharedUiConfiguration.Object);
+        }
+
+        [TestCase("https://test.local")]
+        [TestCase("https://test.local/")]
+        public void Then_The_Url_Is_Built_From_Action_Controller_And_External_Url(string expectedBaseUrl)
+        {
+            //Arrange
+            var action = "test-action";
+            var controller = "test-controller";
+
+            //Act
+            var actual = _helper.GenerateUrl(new UrlParameters{
+                Id = "123", 
+                Controller = controller, 
+                Action = action
+            });
+
+            //Assert
+            Assert.IsNotNull(actual);
+            Assert.AreEqual($"https://test.local/123/{controller}/{action}", actual);
+        }
+
+        [Test]
+        public void Then_The_Url_Is_Built_From_Action_Controller_And_External_Url_And_IncludesId_If_Supplied()
+        {
+            //Arrange
+            var action = "test-action";
+            var controller = "test-controller";
+            var id = "ABC123";
+
+            //Act
+            var actual = _helper.GenerateUrl(new UrlParameters{
+                Id = id, 
+                Controller = controller, 
+                Action = action
+            });
+
+            //Assert
+            Assert.IsNotNull(actual);
+            Assert.AreEqual($"https://test.local/{id}/{controller}/{action}", actual);
+        }
+
+        [Test]
+        public void Then_The_Url_Builds_From_Optional_Parameters()
+        {
+            //Arrange
+            var controller = "test-controller";
+            var id = "ABC123";
+
+            //Act
+            var actual = _helper.GenerateUrl(new UrlParameters{
+                Id = id, 
+                Controller = controller
+            });
+
+            //Assert
+            Assert.IsNotNull(actual);
+            Assert.AreEqual($"https://test.local/{id}/{controller}", actual);
+        }
+
+        [Test]
+        public void Then_The_Url_Builds_From_Controller()
+        {
+            //Arrange
+            var controller = "test-controller";
+
+            //Act
+            var actual = _helper.GenerateUrl(new UrlParameters{
+                Controller = controller
+            });
+
+            //Assert
+            Assert.IsNotNull(actual);
+            Assert.AreEqual($"https://test.local/{controller}", actual);
+        }
+
+        [Test]
+        public void Then_The_SubDomain_Is_Set_If_Passed()
+        {
+            //Arrange
+            var controller = "test-controller";
+            var subDomain = "testDomain";
+
+            //Act
+            var actual = _helper.GenerateUrl(new UrlParameters{
+                Controller = controller, 
+                SubDomain = subDomain
+            });
+
+            //Assert
+            Assert.IsNotNull(actual);
+            Assert.AreEqual($"https://{subDomain}.test.local/{controller}", actual);
+        }
+
+        [Test]
+        public void Then_The_Query_String_Is_Appended()
+        {
+            //Arrange
+            var controller = "test-controller";
+            var subDomain = "testDomain";
+            var queryString = "?test=12345";
+
+            //Act
+            var actual = _helper.GenerateUrl(new UrlParameters{
+                Controller = controller, 
+                SubDomain = subDomain,
+                QueryString = queryString
+            });
+
+            //Assert
+            Assert.IsNotNull(actual);
+            Assert.AreEqual($"https://{subDomain}.test.local/{controller}?test=12345", actual);
+        }
+    }
+}

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI.Tests/SFA.DAS.Provider.Shared.UI.Tests.csproj
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI.Tests/SFA.DAS.Provider.Shared.UI.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Extensions/ExternalUrlHelper.cs
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Extensions/ExternalUrlHelper.cs
@@ -1,0 +1,75 @@
+using System.Text;
+using Microsoft.Extensions.Options;
+using SFA.DAS.Provider.Shared.UI.Models;
+
+namespace SFA.DAS.Provider.Shared.UI.Extensions
+{
+    public interface IExternalUrlHelper
+    {
+        string GenerateUrl(UrlParameters urlParameters);
+    }
+    public class ExternalUrlHelper : IExternalUrlHelper
+    {
+        private readonly ProviderSharedUIConfiguration _options;
+
+        public ExternalUrlHelper(IOptions<ProviderSharedUIConfiguration> options)
+        {
+            _options = options.Value;
+        }
+
+        public string GenerateUrl(UrlParameters urlParameters)
+        {
+            var baseUrl = _options.DashboardUrl;
+
+            return FormatUrl(baseUrl, urlParameters);
+        }
+
+        private static string FormatUrl(string baseUrl, UrlParameters urlParameters)
+        {
+            var urlString = new StringBuilder();
+
+            urlString.Append(FormatBaseUrl(baseUrl, urlParameters.SubDomain, urlParameters.Folder));
+
+            if (!string.IsNullOrEmpty(urlParameters.Id))
+            {
+                urlString.Append($"{urlParameters.Id}/");
+            }
+
+            if (!string.IsNullOrEmpty(urlParameters.Controller))
+            {
+                urlString.Append($"{urlParameters.Controller}/");
+            }
+
+            if (!string.IsNullOrEmpty(urlParameters.Action))
+            {
+                urlString.Append($"{urlParameters.Action}/");
+            }
+
+            if (!string.IsNullOrEmpty(urlParameters.QueryString))
+            {
+                return $"{urlString.ToString().TrimEnd('/')}{urlParameters.QueryString}";
+            }
+
+            return urlString.ToString().TrimEnd('/');
+        }
+
+        private static string FormatBaseUrl(string url, string subDomain = "", string folder = "")
+        {
+            var returnUrl = url.EndsWith("/")
+                ? url
+                : url + "/";
+
+            if (!string.IsNullOrEmpty(subDomain))
+            {
+                returnUrl = returnUrl.Replace("https://", $"https://{subDomain}.");
+            }
+
+            if (!string.IsNullOrEmpty(folder))
+            {
+                returnUrl = $"{returnUrl}{folder}/";
+            }
+
+            return returnUrl;
+        }
+    }
+}

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Models/ProviderSharedUIConfiguration.cs
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Models/ProviderSharedUIConfiguration.cs
@@ -1,0 +1,9 @@
+using Microsoft.Extensions.Configuration;
+
+namespace SFA.DAS.Provider.Shared.UI.Models
+{
+    public class ProviderSharedUIConfiguration 
+    {
+        public string DashboardUrl { get ; set ; }
+    }
+}

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Models/UrlParameters.cs
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Models/UrlParameters.cs
@@ -1,0 +1,12 @@
+namespace SFA.DAS.Provider.Shared.UI.Models
+{
+    public class UrlParameters
+    {
+        public string Id { get; set; }
+        public string Controller { get; set; }
+        public string Action { get; set; }
+        public string SubDomain { get; set; }
+        public string Folder { get; set; }
+        public string QueryString { get; set; }
+    }
+}

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI.csproj
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="SFA.DAS.ProviderUrlHelper" Version="1.1.749" />
-    <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.15" />
+    <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.21" />
   </ItemGroup>
 </Project>

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Startup/AddServiceExtensions.cs
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Startup/AddServiceExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using SFA.DAS.Provider.Shared.UI.Extensions;
+using SFA.DAS.Provider.Shared.UI.Models;
+
+namespace SFA.DAS.Provider.Shared.UI.Startup
+{
+    public static class AddServiceExtensions
+    {
+        public static void AddProviderUiServiceRegistration(this IServiceCollection services, IConfiguration configuration)
+        {
+            if(!configuration.GetSection(nameof(ProviderSharedUIConfiguration)).GetChildren().Any())
+            {
+                throw new Exception("Cannot find ProviderSharedUIConfiguration in configuration. Please add a section called ProviderSharedUIConfiguration with DashboardUrl property");
+            }
+            
+            services.Configure<ProviderSharedUIConfiguration>(configuration.GetSection(nameof(ProviderSharedUIConfiguration)));
+            services.AddSingleton(cfg => cfg.GetService<IOptions<ProviderSharedUIConfiguration>>().Value);
+            services.AddSingleton<IExternalUrlHelper, ExternalUrlHelper>();
+        }
+    }
+}

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Startup/Extensions.cs
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Startup/Extensions.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using SFA.DAS.Provider.Shared.UI.Attributes;
-using SFA.DAS.Provider.Shared.UI.Extensions;
 using SFA.DAS.Provider.Shared.UI.Models;
 
 namespace SFA.DAS.Provider.Shared.UI.Startup
@@ -63,21 +59,6 @@ namespace SFA.DAS.Provider.Shared.UI.Startup
                 options.Filters.Add(new SetZenDeskValuesAttribute(zenDeskConfiguration));
             });
             return builder;
-        }
-    }
-
-    public static class AddServiceExtensions
-    {
-        public static void AddProviderUiServiceRegistration(this IServiceCollection services, IConfiguration configuration)
-        {
-            if(configuration.GetSection(nameof(ProviderSharedUIConfiguration)) == null)
-            {
-                throw new Exception("Cannot find ProviderSharedUIConfiguration in configuration");
-            }
-            
-            services.Configure<ProviderSharedUIConfiguration>(configuration.GetSection(nameof(ProviderSharedUIConfiguration)));
-            services.AddSingleton(cfg => cfg.GetService<IOptions<ProviderSharedUIConfiguration>>().Value);
-            services.AddSingleton<IExternalUrlHelper, ExternalUrlHelper>();
         }
     }
 }

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Startup/Extensions.cs
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Startup/Extensions.cs
@@ -1,7 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using SFA.DAS.Provider.Shared.UI.Attributes;
+using SFA.DAS.Provider.Shared.UI.Extensions;
 using SFA.DAS.Provider.Shared.UI.Models;
 
 namespace SFA.DAS.Provider.Shared.UI.Startup
@@ -60,6 +63,21 @@ namespace SFA.DAS.Provider.Shared.UI.Startup
                 options.Filters.Add(new SetZenDeskValuesAttribute(zenDeskConfiguration));
             });
             return builder;
+        }
+    }
+
+    public static class AddServiceExtensions
+    {
+        public static void AddProviderUiServiceRegistration(this IServiceCollection services, IConfiguration configuration)
+        {
+            if(configuration.GetSection(nameof(ProviderSharedUIConfiguration)) == null)
+            {
+                throw new Exception("Cannot find ProviderSharedUIConfiguration in configuration");
+            }
+            
+            services.Configure<ProviderSharedUIConfiguration>(configuration.GetSection(nameof(ProviderSharedUIConfiguration)));
+            services.AddSingleton(cfg => cfg.GetService<IOptions<ProviderSharedUIConfiguration>>().Value);
+            services.AddSingleton<IExternalUrlHelper, ExternalUrlHelper>();
         }
     }
 }

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/TagHelpers/ExtendedAnchorTagHelper.cs
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/TagHelpers/ExtendedAnchorTagHelper.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using SFA.DAS.Provider.Shared.UI.Extensions;
+using SFA.DAS.Provider.Shared.UI.Models;
+
+namespace SFA.DAS.Provider.Shared.UI.TagHelpers
+{
+    [HtmlTargetElement("a", Attributes = "asp-external-controller")]
+    public class ExtendedAnchorTagHelper : AnchorTagHelper
+    {
+        private readonly IExternalUrlHelper _helper;
+
+        [HtmlAttributeName("asp-external-action")]
+        public string ExternalAction { get; set; }
+        [HtmlAttributeName("asp-external-id")]
+        public string ExternalId { get; set; }
+        [HtmlAttributeName("asp-external-controller")]
+        public string ExternalController { get; set; }
+        [HtmlAttributeName("asp-external-subdomain")]
+        public string ExternalSubDomain { get; set; }
+        [HtmlAttributeName("asp-external-folder")]
+        public string ExternalFolder { get; set; }
+        [HtmlAttributeName("asp-external-querystring")]
+        public string QueryString { get; set; }
+
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            base.Process(context,output);
+
+            var urlParams = new UrlParameters
+            {
+                Id = ExternalId,
+                Controller = ExternalController,
+                Action = ExternalAction,
+                SubDomain = ExternalSubDomain,
+                Folder = ExternalFolder,
+                QueryString = QueryString
+            };
+            output.Attributes.SetAttribute("href",_helper.GenerateUrl(urlParams));
+        }
+
+        public ExtendedAnchorTagHelper(IHtmlGenerator generator,IExternalUrlHelper helper) : base(generator)
+        {
+            _helper = helper;
+        }
+    }
+}

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Views/Shared/_CookieBanner.cshtml
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Views/Shared/_CookieBanner.cshtml
@@ -1,4 +1,4 @@
-﻿@using SFA.DAS.ProviderUrlHelper.Core
+﻿
 
 <div data-module="cookie-banner" role="region" aria-label="cookie banner" class="das-cookie-banner__wrap">
     <div class="das-cookie-banner">
@@ -6,13 +6,13 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     <h2 class="govuk-heading-m das-cookie-banner__header">Tell us whether you accept cookies</h2>
-                    <p class="das-cookie-banner__message">We use <a href="@Url.ProviderApprenticeshipServiceLink("/cookie-details")" class="govuk-link govuk-link--no-visited-state">cookies to collect information</a> about how you use this service. We use this information to make the service work as well as possible and improve this service.</p>
+                    <p class="das-cookie-banner__message">We use <a asp-external-controller="cookie-details" class="govuk-link govuk-link--no-visited-state">cookies to collect information</a> about how you use this service. We use this information to make the service work as well as possible and improve this service.</p>
                     <div class="das-cookie-banner__buttons">
                         <div class="das-cookie-banner__button-wrap das-cookie-banner__button-accept">
                             <button class="govuk-button das-cookie-banner__button" type="submit" data-accept-cookies="true">Accept all cookies</button>
                         </div>
                         <div class="das-cookie-banner__button-wrap das-cookie-banner__button-settings">
-                            <a href="@Url.ProviderApprenticeshipServiceLink("/cookies")" class="govuk-button das-cookie-banner__button" role="button" id="btn-cookie-settings">Set cookie preferences</a>
+                            <a asp-external-controller="cookies" class="govuk-button das-cookie-banner__button" role="button" id="btn-cookie-settings">Set cookie preferences</a>
                         </div>
                     </div>
                 </div>
@@ -20,7 +20,7 @@
         </div>
         <div class="das-cookie-banner__confirmation govuk-width-container" tabindex="-1">
             <p class="das-cookie-banner__confirmation-message">
-                You've accepted all cookies. You can <a href="@Url.ProviderApprenticeshipServiceLink("/cookies")" class="govuk-link" id="link-cookie-settings">change your cookie settings</a> at any time.
+                You've accepted all cookies. You can <a asp-external-controller="cookies" class="govuk-link" id="link-cookie-settings">change your cookie settings</a> at any time.
             </p>
             <button class="das-cookie-banner__hide-button" data-hide-cookie-banner="true" id="btn-hide-cookie-banner">Hide</button>
         </div>

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Views/Shared/_Layout.cshtml
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Views/Shared/_Layout.cshtml
@@ -1,5 +1,4 @@
 ﻿@using SFA.DAS.Provider.Shared.UI.Extensions
-@using SFA.DAS.ProviderUrlHelper.Core
 @{
     var enableGoogleAnalytics = ViewData.EnableGoogleAnalytics();
     var enableCookieBanner = ViewData.EnableCookieBanner();
@@ -70,7 +69,7 @@
                     </a>
                 </div>
                 <div class="govuk-header__content">
-                    <a href="@Url.ProviderApprenticeshipServiceLink("/")" class="govuk-header__link govuk-header__link--service-name">
+                    <a asp-external-controller="" class="govuk-header__link govuk-header__link--service-name">
                         Apprenticeships
                     </a>
                 </div>
@@ -109,12 +108,12 @@
                     <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
                         <h2 class="govuk-visually-hidden">Support links</h2>
                         <ul class="govuk-footer__inline-list">
-                            <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="@Url.ProviderApprenticeshipServiceLink("help" )">Help</a></li>
+                            <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" asp-external-controller="help">Help</a></li>
                             <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="https://www.surveymonkey.co.uk/r/accessmylevysurvey" target="_blank" aria-label="Give feedback">Feedback </a></li>
-                            <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="@Url.ProviderApprenticeshipServiceLink("privacy")">Privacy</a></li>
-                            <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="@Url.ProviderApprenticeshipServiceLink("cookies")">Cookies</a></li>
-                            <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="@Url.ProviderApprenticeshipServiceLink("terms")">Terms and conditions</a></li>
-                            <li class="govuk-footer__inline-list-item">Built by the <a href="http://gov.uk/sfa" target="_blank" class="govuk-footer__link">Education and Skills Funding Agency</a></li>
+                            <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" asp-external-controller="privacy">Privacy</a></li>
+                            <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" asp-external-controller="cookies">Cookies</a></li>
+                            <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" asp-external-controller="terms">Terms and conditions</a></li>
+                            <li class="govuk-footer__inline-list-item">Built by the <a href="https://www.gov.uk/government/organisations/education-and-skills-funding-agency" target="_blank" class="govuk-footer__link">Education and Skills Funding Agency</a></li>
                         </ul>
                         <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
                             <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Views/Shared/_Layout.cshtml
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Views/Shared/_Layout.cshtml
@@ -15,6 +15,7 @@
 
         <meta charset="utf-8" />
         <title>@ViewData["Title"]</title>
+        <meta name="description" content="@(ViewData["Description"] ?? "")">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="theme-color" content="#0b0c0c" />
 

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Views/Shared/_Menu.cshtml
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Views/Shared/_Menu.cshtml
@@ -1,6 +1,6 @@
 @using SFA.DAS.Provider.Shared.UI
 @using SFA.DAS.Provider.Shared.UI.Extensions
-@using SFA.DAS.ProviderUrlHelper.Core
+
 
 
 @if (Context.User.Identity.IsAuthenticated)
@@ -17,13 +17,13 @@
                 <nav class="das-user-navigation" id="das-user-navigation">
                     <ul class="das-user-navigation__list" role="menu">
                         <li class="das-user-navigation__list-item">
-                            <a href="@Url.ProviderApprenticeshipServiceLink("/")" class="das-user-navigation__link">@Context.User.Identity.Name</a>
+                            <a asp-external-controller="" class="das-user-navigation__link">@Context.User.Identity.Name</a>
                         </li>
                         <li class="das-user-navigation__list-item">
-                            <a href="@Url.ProviderApprenticeshipServiceLink("/notification-settings")" class="das-user-navigation__link">Notification settings</a>
+                            <a asp-external-controller="notification-settings" class="das-user-navigation__link">Notification settings</a>
                         </li>
                         <li class="das-user-navigation__list-item">
-                            <a href="@Url.ProviderApprenticeshipServiceLink("/signout")" class="das-user-navigation__link">Sign out</a>
+                            <a asp-Route="provider-signout" class="das-user-navigation__link">Sign out</a>
                         </li>
                     </ul>
                 </nav>
@@ -39,37 +39,38 @@
                     @if (!suppressed.Contains(NavigationSection.Home))
                     {
                         <li class="das-navigation__list-item">
-                            <a href="@Url.ProviderApprenticeshipServiceLink("/account")" class="das-navigation__link @(selected == NavigationSection.Home ? "das-navigation__link--current" : "")">Home</a>
+                            <a asp-external-controller="Account" class="das-navigation__link @(selected == NavigationSection.Home ? "das-navigation__link--current" : "")">Home</a>
                         </li>
                     }
                     @if (!suppressed.Contains(NavigationSection.YourCohorts))
                     {
                         <li class="das-navigation__list-item">
-                            <a href="@Url.ProviderApprenticeshipServiceLink($"/{providerId}/apprentices/cohorts")" class="das-navigation__link @(selected == NavigationSection.YourCohorts ? "das-navigation__link--current" : "")">Apprentice requests</a>
+                            <a asp-external-action="Cohorts" asp-external-controller="apprentices" asp-external-id="@providerId" class="das-navigation__link @(selected == NavigationSection.YourCohorts ? "das-navigation__link--current" : "")">Apprentice requests</a>
                         </li>
                     }
                     @if (!suppressed.Contains(NavigationSection.Reservations))
                     {
                         <li class="das-navigation__list-item">
-                            <a href="@Url.ReservationsLink($"{providerId}/reservations/manage")" class="das-navigation__link @(selected == NavigationSection.Reservations ? "das-navigation__link--current" : "")">Manage funding</a>
+                            
+                            <a asp-external-action="manage" asp-external-controller="reservations" asp-external-id="@providerId" class="das-navigation__link @(selected == NavigationSection.Reservations ? "das-navigation__link--current" : "")">Manage funding</a>
                         </li>
                     }
                     @if (!suppressed.Contains(NavigationSection.ManageApprentices))
                     {
                         <li class="das-navigation__list-item">
-                            <a href="@Url.ProviderApprenticeshipServiceLink($"/{providerId}/apprentices/manage/all")" class="das-navigation__link @(selected == NavigationSection.ManageApprentices ? "das-navigation__link--current" : "")">Manage your apprentices</a>
+                            <a asp-external-action="manage/all" asp-external-controller="apprentices" asp-external-id="@providerId" class="das-navigation__link @(selected == NavigationSection.ManageApprentices ? "das-navigation__link--current" : "")">Manage your apprentices</a>
                         </li>
                     }
                     @if (!suppressed.Contains(NavigationSection.Recruit))
                     {
                         <li class="das-navigation__list-item">
-                            <a href="@Url.RecruitLink($"{providerId}")" class="das-navigation__link @(selected == NavigationSection.Recruit ? "das-navigation__link--current" : "")">Recruit apprentices</a>
+                            <a asp-external-controller="" asp-external-subdomain="recruit" asp-external-id="@providerId" class="das-navigation__link @(selected == NavigationSection.Recruit ? "das-navigation__link--current" : "")">Recruit apprentices</a>
                         </li>
                     }
                     @if (!suppressed.Contains(NavigationSection.Agreements))
                     {
                         <li class="das-navigation__list-item">
-                            <a href="@Url.ProviderApprenticeshipServiceLink($"/{providerId}/agreements")" class="das-navigation__link @(selected == NavigationSection.Agreements ? "das-navigation__link--current" : "")">Organisations and agreements</a>
+                            <a asp-external-controller="Agreements" asp-external-id="@providerId" class="das-navigation__link @(selected == NavigationSection.Agreements ? "das-navigation__link--current" : "")">Organisations and agreements</a>
                         </li>
                     }
                 </ul>

--- a/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Views/Shared/_ViewImports.cshtml
+++ b/SFA.DAS.Provider.Shared.UI/SFA.DAS.Provider.Shared.UI/Views/Shared/_ViewImports.cshtml
@@ -1,2 +1,3 @@
 ﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, WebEssentials.AspNetCore.CdnTagHelpers
+@addTagHelper *, SFA.DAS.Provider.Shared.UI

--- a/SFA.DAS.Provider.Shared.UI/readme.md
+++ b/SFA.DAS.Provider.Shared.UI/readme.md
@@ -8,11 +8,23 @@ This consists of _Layout and _Menu razor views.
 
 * Only Core web apps are supported.
 * In order for the menu to render, the user must be authenticated and the Provider Id (UKPRN) must be in the claims
-* This package references the ProviderUrlHelper package, which makes use of StructureMap and AutoConfiguration. The current implementation will add StructureMap references to your project and make use of AutoConfiguration. This dependency will be removed in a future version.
 
 ## Usage
 
 * Add a reference to the [SFA.DAS.Provider.Shared.UI](https://www.nuget.org/packages/SFA.DAS.Provider.Shared.UI/) package
+* in your configuration add a section called **ProviderSharedUIConfiguration** with DashboardUrl defined.
+```
+   { 
+      "ProviderSharedUIConfiguration" :
+      {
+         "DashboardUrl":"https://localhost:1234"
+      }   
+   }
+```
+* In startup.cs add the following, where _configuration is an instance of IConfiguration with the above config loaded:
+```
+services.AddProviderUiServiceRegistration(_configuration);
+```
 * Remove any local shared views called \_Layout.cshtml or \_Menu.cshtml, otherwise these will take precedence over those in the package
 * Your application must set the selected navigation section by:
    * Calling the `SetDefaultNavigationSection` in the application startup, passing your default navigation section as a parameter (if this is adequate, nothing further is required)

--- a/SFA.DAS.Provider.Shared.UI/readme.md
+++ b/SFA.DAS.Provider.Shared.UI/readme.md
@@ -1,6 +1,6 @@
 # SFA.DAS.Provider.Shared.UI
 
-This package provides shared Provider UI components via a [Razor Class Library](https://docs.microsoft.com/en-us/aspnet/core/razor-pages/ui-class?view=aspnetcore-2.2&tabs=visual-studio).
+This package provides shared Provider UI components via a [Razor Class Library](https://docs.microsoft.com/en-us/aspnet/core/razor-pages/ui-class?view=aspnetcore-3.1&tabs=visual-studio).
 
 This consists of _Layout and _Menu razor views.
 
@@ -12,7 +12,7 @@ This consists of _Layout and _Menu razor views.
 ## Usage
 
 * Add a reference to the [SFA.DAS.Provider.Shared.UI](https://www.nuget.org/packages/SFA.DAS.Provider.Shared.UI/) package
-* in your configuration add a section called **ProviderSharedUIConfiguration** with DashboardUrl defined.
+* In your configuration add a section called **ProviderSharedUIConfiguration** with DashboardUrl defined.
 ```
    { 
       "ProviderSharedUIConfiguration" :
@@ -32,7 +32,7 @@ services.AddProviderUiServiceRegistration(_configuration);
 * Prevent the menu from being displayed by decorating controllers or individual action methods with the `HideNavigationBar` attribute filter
 * Show a "Beta" phase banner in the layout for your service by calling the `ShowBetaPhaseBanner` startup extension method (or adding the `ShowBetaPhaseBanner` attribute filter as appropriate)
 * Suppress navigation sections (for example, if an up-coming service is toggled off) by using the `SuppressNavigationSection` extension method
- 
+* The package also requires that you implement your own sign out action. This is expecting a controller action with the route name of `provider-signout` 
 Examples: 
 
  ```csharp


### PR DESCRIPTION
Upgrade package to 3.1 from 2.2
Remove dependency on `SFA.DAS.ProviderUrlHelper`
There is now no dependency on StructureMap or AutoConfiguration.

To use, the following configuration element needs to be present:
```
{ 
         "ProviderSharedUIConfiguration" :
         {
                 "DashboardUrl":"https://localhost:1234"
         }
```
This can exist in your main configuration, as long as it is loaded during startup.

Then in Startup add
```
services.AddProviderUiServiceRegistration(_configuration);
```

Which will add the remaining container registration