### PR TITLE
Improvements to DfESignInService

### DIFF
--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInAuthenticationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInAuthenticationExtension.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
 using SFA.DAS.DfESignIn.Auth.Configuration;
 using SFA.DAS.DfESignIn.Auth.Interfaces;
 using System;
@@ -38,6 +39,10 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
                     options.CallbackPath = "/sign-in";
                     options.SaveTokens = true;
                     options.GetClaimsFromUserInfoEndpoint = true;
+                    options.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        AuthenticationType = OpenIdConnectDefaults.AuthenticationScheme
+                    };
 
                     var scopes = "openid email profile organisation organisationid".Split(' ');
                     options.Scope.Clear();

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Services/DfESignInService.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Services/DfESignInService.cs
@@ -78,7 +78,7 @@ namespace SFA.DAS.DfESignIn.Auth.Services
                         .AddClaim(new Claim(CustomClaimsIdentity.Service, role.Name));
                 }
 
-                ctx?.Principal?.AddIdentity(new ClaimsIdentity(roleClaims));
+                ctx?.Principal?.Identities.First().AddClaims(roleClaims);
             }
         }
     }


### PR DESCRIPTION
1) Adding the claims to initial identity rather than creating new identity. 
2) Explicitly define the AuthenticationType as OpenIdConnect otherwise the default will be WSFederation.