### PR TITLE
Introducing CustomServiceRole to instantiate Service Role from client/service application while using DfeSignIn Authentication services.

### DIFF
--- a/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/AppStart/AddServiceRegistrationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/AppStart/AddServiceRegistrationExtension.cs
@@ -13,7 +13,7 @@ public static class AddServiceRegistrationExtension
         services.AddHttpContextAccessor();
         services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
         services.AddSingleton<IUrlHelperFactory, UrlHelperFactory>();
-        services.AddAndConfigureDfESignInAuthentication(configuration, $"{typeof(AddServiceRegistrationExtension).Assembly.GetName().Name}.Auth");
+        services.AddAndConfigureDfESignInAuthentication(configuration, $"{typeof(AddServiceRegistrationExtension).Assembly.GetName().Name}.Auth", typeof(CustomServiceRole));
         services.AddProviderUiServiceRegistration(configuration);
     }
 }

--- a/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/AppStart/CustomServiceRole.cs
+++ b/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/AppStart/CustomServiceRole.cs
@@ -1,0 +1,10 @@
+﻿using SFA.DAS.DfESignIn.Auth.Constants;
+using SFA.DAS.DfESignIn.Auth.Interfaces;
+
+namespace SFA.DAS.DfESignIn.SampleSite.AppStart
+{
+    public class CustomServiceRole : ICustomServiceRole
+    {
+        public string RoleClaimType => CustomClaimsIdentity.Service;
+    }
+}

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/AppStart/WhenAddingServicesToTheContainer.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/AppStart/WhenAddingServicesToTheContainer.cs
@@ -7,6 +7,7 @@ using SFA.DAS.DfESignIn.Auth.AppStart;
 using SFA.DAS.DfESignIn.Auth.Interfaces;
 using SFA.DAS.DfESignIn.Auth.Configuration;
 using SFA.DAS.DfESignIn.Auth.Api.Helpers;
+using SFA.DAS.DfESignIn.Auth.Constants;
 
 namespace SFA.DAS.DfESignIn.Auth.UnitTests.AppStart;
 
@@ -33,7 +34,7 @@ public class WhenAddingServicesToTheContainer
     private static void SetupServiceCollection(IServiceCollection serviceCollection)
     {
         var configuration = GenerateConfiguration();
-        serviceCollection.AddServiceRegistration(configuration);
+        serviceCollection.AddServiceRegistration(configuration, typeof(TestCustomServiceRole));
     }
 
     private static IConfigurationRoot GenerateConfiguration()
@@ -61,5 +62,10 @@ public class WhenAddingServicesToTheContainer
         {
             throw new NotImplementedException();
         }
+    }
+
+    public class TestCustomServiceRole : ICustomServiceRole
+    {
+        public string RoleClaimType => throw new NotImplementedException();
     }
 }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddAndConfigureDfESignInAuthenticationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddAndConfigureDfESignInAuthenticationExtension.cs
@@ -6,9 +6,9 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
 {
     public static class AddAndConfigureDfESignInAuthenticationExtension
     {
-        public static void AddAndConfigureDfESignInAuthentication(this IServiceCollection services, IConfiguration configuration, string authenticationCookieName)
+        public static void AddAndConfigureDfESignInAuthentication(this IServiceCollection services, IConfiguration configuration, string authenticationCookieName, Type customServiceRole)
         {
-            services.AddServiceRegistration(configuration);
+            services.AddServiceRegistration(configuration, customServiceRole);
             if (!string.IsNullOrEmpty(configuration["NoAuthEmail"]))
             {
                 services.AddProviderStubAuthentication($"{authenticationCookieName}.stub");

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddServiceRegistrationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddServiceRegistrationExtension.cs
@@ -16,7 +16,7 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
 {
     internal static class AddServiceRegistrationExtension
     {
-        internal static void AddServiceRegistration(this IServiceCollection services, IConfiguration configuration)
+        internal static void AddServiceRegistration(this IServiceCollection services, IConfiguration configuration, Type customServiceRole)
         {
             if (!configuration.GetSection(nameof(DfEOidcConfiguration)).GetChildren().Any())
             {
@@ -32,6 +32,7 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
 #endif
 
             services.AddSingleton(cfg => cfg.GetService<IOptions<DfEOidcConfiguration>>().Value);
+            services.AddTransient(typeof(ICustomServiceRole), customServiceRole);
             services.AddTransient<IDfESignInService, DfESignInService>();
             services.AddHttpClient<IApiHelper, DfeSignInApiHelper>
                 (

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Interfaces/ICustomServiceRole.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Interfaces/ICustomServiceRole.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.DfESignIn.Auth.Interfaces
+{
+    public interface ICustomServiceRole
+    {
+        string RoleClaimType { get; }
+    }
+}

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Services/DfESignInService.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Services/DfESignInService.cs
@@ -21,15 +21,17 @@ namespace SFA.DAS.DfESignIn.Auth.Services
     internal class DfESignInService : IDfESignInService
     {
         private readonly DfEOidcConfiguration _configuration;
-        
         private readonly IApiHelper _apiHelper;
+        private readonly ICustomServiceRole _customServiceRole;
 
         public DfESignInService(
             IOptions<DfEOidcConfiguration> configuration,
-            IApiHelper apiHelper)
+            IApiHelper apiHelper,
+            ICustomServiceRole customServiceRole)
         {
             _configuration = configuration.Value;
             _apiHelper = apiHelper;
+            _customServiceRole = customServiceRole;
         }
 
         public async Task PopulateAccountClaims(TokenValidatedContext ctx)
@@ -74,8 +76,9 @@ namespace SFA.DAS.DfESignIn.Auth.Services
                     roleClaims.Add(new Claim(ClaimName.RoleNumericId, role.NumericId.ToString(), ClaimTypes.Role, ctx.Options.ClientId));
 
                     // Add to initial identity
+                    // Check if the custom service role type is set in client side if not use the default CustomClaimsIdentity.Service
                     ctx.Principal?.Identities.First()
-                        .AddClaim(new Claim(CustomClaimsIdentity.Service, role.Name));
+                        .AddClaim(new Claim(_customServiceRole.RoleClaimType ?? CustomClaimsIdentity.Service, role.Name));
                 }
 
                 ctx?.Principal?.Identities.First().AddClaims(roleClaims);


### PR DESCRIPTION
Introducing CustomServiceRole to instantiate Service Role from client/service application while using DfeSignIn Authentication services.

CustomServiceRoles could be
"http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
"http://schemas.portal.com/service"