### PR TITLE
FAI-841 Change configuration in DfESignIn package to support multiple client registrations

### DIFF
--- a/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/AppStart/AddServiceRegistrationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/AppStart/AddServiceRegistrationExtension.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Routing;
-using Microsoft.Extensions.Configuration;
 using SFA.DAS.DfESignIn.Auth.AppStart;
 using SFA.DAS.Provider.Shared.UI.Startup;
 
@@ -8,12 +7,17 @@ namespace SFA.DAS.DfESignIn.SampleSite.AppStart;
 
 public static class AddServiceRegistrationExtension
 {
+    // For testing purpose we have mentioned the ClientName as "QA".
+    // This client name value has to be same as OpenID Connect Client Id
+    // https://test-manage.signin.education.gov.uk/services/9F92718F-FCC5-4CDA-8F80-EEA8004FE089/service-configuration
+    private const string ClientName = "QA";
+
     public static void AddServiceRegistration(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddHttpContextAccessor();
         services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
         services.AddSingleton<IUrlHelperFactory, UrlHelperFactory>();
-        services.AddAndConfigureDfESignInAuthentication(configuration, $"{typeof(AddServiceRegistrationExtension).Assembly.GetName().Name}.Auth", typeof(CustomServiceRole));
+        services.AddAndConfigureDfESignInAuthentication(configuration, $"{typeof(AddServiceRegistrationExtension).Assembly.GetName().Name}.Auth", typeof(CustomServiceRole), ClientName);
         services.AddProviderUiServiceRegistration(configuration);
     }
 }

--- a/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/Controllers/HomeController.cs
+++ b/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/Controllers/HomeController.cs
@@ -26,7 +26,7 @@ public class HomeController : Controller
     
     [Authorize]
     [HttpGet]
-    [Route("sign-out")]
+    [Route("signed-out")]
     public async Task<IActionResult> SigningOut()
     {
         var idToken = await HttpContext.GetTokenAsync("id_token");

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/AppStart/WhenAddingServicesToTheContainer.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/AppStart/WhenAddingServicesToTheContainer.cs
@@ -3,17 +3,19 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using SFA.DAS.DfESignIn.Auth.AppStart;
 using SFA.DAS.DfESignIn.Auth.Interfaces;
 using SFA.DAS.DfESignIn.Auth.Configuration;
 using SFA.DAS.DfESignIn.Auth.Api.Helpers;
-using SFA.DAS.DfESignIn.Auth.Constants;
 
 namespace SFA.DAS.DfESignIn.Auth.UnitTests.AppStart;
 
 
 public class WhenAddingServicesToTheContainer
 {
+    private const string ClientName = "someProvider";
+
     [TestCase(typeof(DfEOidcConfiguration))]
     [TestCase(typeof(IDfESignInService))]
     [TestCase(typeof(ITokenDataSerializer))]
@@ -31,10 +33,43 @@ public class WhenAddingServicesToTheContainer
         Assert.That(type, Is.Not.Null);
     }
 
+    [Test]
+    [TestCase(null)]
+    [TestCase("")]
+    public void Then_The_ClientName_Given_NullOrEmpty_Throw_Exception(string clientName)
+    {
+        // arrange
+        var configuration = GenerateConfiguration();
+        var serviceCollection = new ServiceCollection();
+
+        // sut
+        Assert.Throws<ArgumentNullException>(() => 
+            serviceCollection.AddServiceRegistration(configuration, typeof(TestCustomServiceRole), clientName));
+    }
+
+    [Test]
+    public void Then_The_Configuration_Given_NullOrEmpty_Throw_Exception()
+    {
+        // arrange
+        var configuration = new ConfigurationRoot(new List<IConfigurationProvider>
+        { 
+            new MemoryConfigurationProvider(new MemoryConfigurationSource
+            {
+                InitialData = new List<KeyValuePair<string, string>>()
+
+            })
+        });
+        var serviceCollection = new ServiceCollection();
+
+        // sut
+        Assert.Throws<ArgumentException>(() =>
+            serviceCollection.AddServiceRegistration(configuration, typeof(TestCustomServiceRole), It.IsAny<string>()));
+    }
+
     private static void SetupServiceCollection(IServiceCollection serviceCollection)
     {
         var configuration = GenerateConfiguration();
-        serviceCollection.AddServiceRegistration(configuration, typeof(TestCustomServiceRole));
+        serviceCollection.AddServiceRegistration(configuration, typeof(TestCustomServiceRole), ClientName);
     }
 
     private static IConfigurationRoot GenerateConfiguration()

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddAndConfigureDfESignInAuthenticationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddAndConfigureDfESignInAuthenticationExtension.cs
@@ -6,16 +6,16 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
 {
     public static class AddAndConfigureDfESignInAuthenticationExtension
     {
-        public static void AddAndConfigureDfESignInAuthentication(this IServiceCollection services, IConfiguration configuration, string authenticationCookieName, Type customServiceRole)
+        public static void AddAndConfigureDfESignInAuthentication(this IServiceCollection services, IConfiguration configuration, string authenticationCookieName, Type customServiceRole, string clientName)
         {
-            services.AddServiceRegistration(configuration, customServiceRole);
+            services.AddServiceRegistration(configuration, customServiceRole, clientName);
             if (!string.IsNullOrEmpty(configuration["NoAuthEmail"]))
             {
                 services.AddProviderStubAuthentication($"{authenticationCookieName}.stub");
             }
             else
             {
-                services.ConfigureDfESignInAuthentication(configuration, authenticationCookieName);
+                services.ConfigureDfESignInAuthentication(configuration, authenticationCookieName, clientName);
             }
         }
     }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddServiceRegistrationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddServiceRegistrationExtension.cs
@@ -16,7 +16,7 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
 {
     internal static class AddServiceRegistrationExtension
     {
-        internal static void AddServiceRegistration(this IServiceCollection services, IConfiguration configuration, Type customServiceRole)
+        internal static void AddServiceRegistration(this IServiceCollection services, IConfiguration configuration, Type customServiceRole, string clientName)
         {
             if (!configuration.GetSection(nameof(DfEOidcConfiguration)).GetChildren().Any())
             {
@@ -24,11 +24,16 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
                     "Cannot find DfEOidcConfiguration in configuration. Please add a section called DfESignInOidcConfiguration with BaseUrl, ClientId and Secret properties.");
             }
 
+            if (string.IsNullOrEmpty(clientName))
+                throw new ArgumentNullException(nameof(clientName), "ClientName cannot be null or empty");
+
             services.AddOptions();
 #if NETSTANDARD2_0
             services.Configure<DfEOidcConfiguration>(options => configuration.GetSection(nameof(DfEOidcConfiguration)).Bind(options));
+            services.Configure<DfEOidcConfiguration>(options => configuration.GetSection($"{nameof(DfEOidcConfiguration)}_{clientName}").Bind(options));
 #else 
             services.Configure<DfEOidcConfiguration>(configuration.GetSection(nameof(DfEOidcConfiguration)));
+            services.Configure<DfEOidcConfiguration>(configuration.GetSection($"{nameof(DfEOidcConfiguration)}_{clientName}"));
 #endif
 
             services.AddSingleton(cfg => cfg.GetService<IOptions<DfEOidcConfiguration>>().Value);

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInAuthenticationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInAuthenticationExtension.cs
@@ -16,8 +16,11 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
 {
     internal static class ConfigureDfESignInAuthenticationExtension
     {
-        internal static void ConfigureDfESignInAuthentication(this IServiceCollection services,
-            IConfiguration configuration, string authenticationCookieName)
+        internal static void ConfigureDfESignInAuthentication(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            string authenticationCookieName,
+            string clientName)
         {
             services
                 .AddAuthentication(sharedOptions =>
@@ -29,8 +32,8 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
                 })
                 .AddOpenIdConnect(options =>
                 {
-                    options.ClientId = configuration["DfEOidcConfiguration:ClientId"];
-                    options.ClientSecret = configuration["DfEOidcConfiguration:Secret"];
+                    options.ClientId = configuration[$"DfEOidcConfiguration_{clientName}:ClientId"];
+                    options.ClientSecret = configuration[$"DfEOidcConfiguration_{clientName}:Secret"];
                     options.MetadataAddress = $"{configuration["DfEOidcConfiguration:BaseUrl"]}/.well-known/openid-configuration";
                     options.ResponseType = "code";
                     options.AuthenticationMethod = OpenIdConnectRedirectBehavior.RedirectGet;


### PR DESCRIPTION
Commit Details:
1) Introduced ClientName as a additional paramter under Service Registration. 
2) Ability to hold and read unique Client Configuration settings from from SFA.DAS.Provider.DfeSignIn_1.0 
3) More Unit test to cover the additional code changes

Story Link: https://skillsfundingagency.atlassian.net/browse/FAI-841

![image](https://user-images.githubusercontent.com/2102434/236215218-f331c92f-3c26-4a23-b054-d7267e83f391.png)
