### PR TITLE
FAI-853 Improvement to DfESignIn Nuget Package and configuration

### DIFF
--- a/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite.Standard/Views/Home/Authenticated.cshtml
+++ b/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite.Standard/Views/Home/Authenticated.cshtml
@@ -24,4 +24,4 @@
     </tbody>
 </table>
 
-<a asp-action="SigningOut" asp-controller="Home" class="govuk-button">Sign Out</a>
+<a asp-action="signed-out" asp-controller="Home" class="govuk-button">Sign Out</a>

--- a/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/AppStart/AddServiceRegistrationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/AppStart/AddServiceRegistrationExtension.cs
@@ -11,13 +11,19 @@ public static class AddServiceRegistrationExtension
     // This client name value has to be same as OpenID Connect Client Id
     // https://test-manage.signin.education.gov.uk/services/9F92718F-FCC5-4CDA-8F80-EEA8004FE089/service-configuration
     private const string ClientName = "QA";
+    private const string SignedOutCallbackPath = "/signed-out";
 
     public static void AddServiceRegistration(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddHttpContextAccessor();
         services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
         services.AddSingleton<IUrlHelperFactory, UrlHelperFactory>();
-        services.AddAndConfigureDfESignInAuthentication(configuration, $"{typeof(AddServiceRegistrationExtension).Assembly.GetName().Name}.Auth", typeof(CustomServiceRole), ClientName);
+        services.AddAndConfigureDfESignInAuthentication(
+            configuration,
+            $"{typeof(AddServiceRegistrationExtension).Assembly.GetName().Name}.Auth",
+            typeof(CustomServiceRole),
+            ClientName, 
+            SignedOutCallbackPath);
         services.AddProviderUiServiceRegistration(configuration);
     }
 }

--- a/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/AppStart/CustomServiceRole.cs
+++ b/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/AppStart/CustomServiceRole.cs
@@ -7,6 +7,8 @@ namespace SFA.DAS.DfESignIn.SampleSite.AppStart
     public class CustomServiceRole : ICustomServiceRole
     {
         public string RoleClaimType => CustomClaimsIdentity.Service;
+
+        // <inherit-doc/>
         public CustomServiceRoleValueType RoleValueType => CustomServiceRoleValueType.Name;
     }
 }

--- a/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/AppStart/CustomServiceRole.cs
+++ b/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/AppStart/CustomServiceRole.cs
@@ -1,4 +1,5 @@
 ﻿using SFA.DAS.DfESignIn.Auth.Constants;
+using SFA.DAS.DfESignIn.Auth.Enums;
 using SFA.DAS.DfESignIn.Auth.Interfaces;
 
 namespace SFA.DAS.DfESignIn.SampleSite.AppStart
@@ -6,5 +7,6 @@ namespace SFA.DAS.DfESignIn.SampleSite.AppStart
     public class CustomServiceRole : ICustomServiceRole
     {
         public string RoleClaimType => CustomClaimsIdentity.Service;
+        public CustomServiceRoleValueType RoleValueType => CustomServiceRoleValueType.Name;
     }
 }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/AppStart/WhenAddingCustomServiceRoleTest.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/AppStart/WhenAddingCustomServiceRoleTest.cs
@@ -1,0 +1,22 @@
+﻿using Moq;
+using SFA.DAS.DfESignIn.Auth.Enums;
+using SFA.DAS.DfESignIn.Auth.Interfaces;
+
+namespace SFA.DAS.DfESignIn.Auth.UnitTests.AppStart
+{
+    public class WhenAddingCustomServiceRoleTest
+    {
+        [TestCase(CustomServiceRoleValueType.Code, null)]
+        [TestCase(CustomServiceRoleValueType.Name ,"http://schemas.portal.com/displayname")]
+        public void Then_The_Properties_Are_Correctly_Returned(CustomServiceRoleValueType roleValue, string roleClaim)
+        {
+            // arrange
+            var customServiceRole = new Mock<ICustomServiceRole>();
+            customServiceRole.Setup(c => c.RoleValueType).Returns(roleValue);
+            customServiceRole.Setup(c => c.RoleClaimType).Returns(roleClaim);
+            
+            // assert
+            Assert.That(customServiceRole.Object.RoleClaimType, Is.EqualTo(roleClaim));
+        }
+    }
+}

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/AppStart/WhenAddingServicesToTheContainer.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/AppStart/WhenAddingServicesToTheContainer.cs
@@ -8,6 +8,7 @@ using SFA.DAS.DfESignIn.Auth.AppStart;
 using SFA.DAS.DfESignIn.Auth.Interfaces;
 using SFA.DAS.DfESignIn.Auth.Configuration;
 using SFA.DAS.DfESignIn.Auth.Api.Helpers;
+using SFA.DAS.DfESignIn.Auth.Enums;
 
 namespace SFA.DAS.DfESignIn.Auth.UnitTests.AppStart;
 
@@ -102,5 +103,6 @@ public class WhenAddingServicesToTheContainer
     public class TestCustomServiceRole : ICustomServiceRole
     {
         public string RoleClaimType => throw new NotImplementedException();
+        public CustomServiceRoleValueType RoleValueType => CustomServiceRoleValueType.Name;
     }
 }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Enums/CustomServiceRoleValueTypeTest.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Enums/CustomServiceRoleValueTypeTest.cs
@@ -1,0 +1,26 @@
+﻿using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SFA.DAS.DfESignIn.Auth.Enums;
+using SFA.DAS.DfESignIn.Auth.Interfaces;
+
+namespace SFA.DAS.DfESignIn.Auth.UnitTests.Enums
+{
+    public class CustomServiceRoleValueTypeTest
+    {
+        [TestCaseSource(nameof(CustomServiceRoleEnumValues))]
+        public void Then_The_Properties_Are_Correctly_Returned(CustomServiceRoleValueType roleValue)
+        {
+            // assert
+            Assert.That(Convert.ToInt32(roleValue) > 0, Is.EqualTo(true));
+        }
+
+        private static IEnumerable<object[]> CustomServiceRoleEnumValues()
+        {
+            return from object? number in Enum.GetValues(typeof(CustomServiceRoleValueType)) select new object[] { number };
+        }
+    }
+}

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Services/DfESignInServiceTest.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Services/DfESignInServiceTest.cs
@@ -33,6 +33,7 @@ namespace SFA.DAS.DfESignIn.Auth.UnitTests.Services
             apiHelper.Setup(x => x.Get<ApiServiceResponse>($"{config.APIServiceUrl}/services/{config.APIServiceId}/organisations/{organisation.Id}/users/{userId}")).ReturnsAsync(response);
             configuration.Setup(c => c.Value).Returns(config);
             customServiceRole.Setup(role => role.RoleClaimType).Returns(CustomClaimsIdentity.Service);
+            customServiceRole.Setup(role => role.RoleValueType).Returns(CustomServiceRoleValueType.Name);
             var service = new DfESignInService(configuration.Object, apiHelper.Object, customServiceRole.Object);
 
             await service.PopulateAccountClaims(tokenValidatedContext);
@@ -59,6 +60,7 @@ namespace SFA.DAS.DfESignIn.Auth.UnitTests.Services
             apiHelper.Setup(x => x.Get<ApiServiceResponse>($"{config.APIServiceUrl}/services/{config.APIServiceId}/organisations/{organisation.Id}/users/{userId}")).ReturnsAsync(response);
             configuration.Setup(c => c.Value).Returns(config);
             customServiceRole.Setup(role => role.RoleClaimType).Returns(CustomClaimsIdentity.Service);
+            customServiceRole.Setup(role => role.RoleValueType).Returns(CustomServiceRoleValueType.Name);
             var service = new DfESignInService(configuration.Object, apiHelper.Object, customServiceRole.Object);
 
             await service.PopulateAccountClaims(tokenValidatedContext);

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Services/DfESignInServiceTest.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Services/DfESignInServiceTest.cs
@@ -34,7 +34,7 @@ namespace SFA.DAS.DfESignIn.Auth.UnitTests.Services
             configuration.Setup(c => c.Value).Returns(config);
             customServiceRole.Setup(role => role.RoleClaimType).Returns(CustomClaimsIdentity.Service);
             var service = new DfESignInService(configuration.Object, apiHelper.Object, customServiceRole.Object);
-                
+
             await service.PopulateAccountClaims(tokenValidatedContext);
 
             var actualClaims = tokenValidatedContext.Principal?.Identities.First().Claims.ToList();
@@ -43,7 +43,7 @@ namespace SFA.DAS.DfESignIn.Auth.UnitTests.Services
             actualClaims?.First(c => c.Type.Equals(ClaimName.Sub)).Value.Should().Be(userId);
             actualClaims?.First(c => c.Type.Equals(CustomClaimsIdentity.DisplayName)).Value.Should().Be("Test Tester");
         }
-        
+
         [Test, MoqAutoData]
         public async Task Then_The_Organisations_Are_Added_To_The_Claims(
             string userId,
@@ -55,7 +55,7 @@ namespace SFA.DAS.DfESignIn.Auth.UnitTests.Services
             [Frozen] Mock<ICustomServiceRole> customServiceRole)
         {
             var tokenValidatedContext = ArrangeTokenValidatedContext(userId, organisation, string.Empty);
-            response.Roles = response.Roles.Select(c => {c.Status.Id = (int)RoleStatus.Active; return c;}).ToList();
+            response.Roles = response.Roles.Select(c => { c.Status.Id = (int)RoleStatus.Active; return c; }).ToList();
             apiHelper.Setup(x => x.Get<ApiServiceResponse>($"{config.APIServiceUrl}/services/{config.APIServiceId}/organisations/{organisation.Id}/users/{userId}")).ReturnsAsync(response);
             configuration.Setup(c => c.Value).Returns(config);
             customServiceRole.Setup(role => role.RoleClaimType).Returns(CustomClaimsIdentity.Service);
@@ -66,7 +66,6 @@ namespace SFA.DAS.DfESignIn.Auth.UnitTests.Services
             var claims = tokenValidatedContext.Principal?.Identities.Last().Claims.ToList();
             if (claims != null)
             {
-
                 claims.Where(x => x.Type.Equals(ClaimName.RoleCode)).Select(c => c.Value).Should()
                     .BeEquivalentTo(response.Roles.Select(c => c.Code).ToList());
                 claims.Where(x => x.Type.Equals(ClaimName.RoleId)).Select(c => c.Value).Should()
@@ -78,29 +77,31 @@ namespace SFA.DAS.DfESignIn.Auth.UnitTests.Services
                 claims.Where(x => x.Type.Equals(CustomClaimsIdentity.Service)).Select(c => c.Value).Should()
                     .BeEquivalentTo(response.Roles.Select(c => c.Name).ToList());
             }
-                
         }
-        
-        private TokenValidatedContext ArrangeTokenValidatedContext(string userId, Organisation organisation, string emailAddress)
+
+        private static TokenValidatedContext ArrangeTokenValidatedContext(string userId, Organisation organisation, string emailAddress)
         {
-            var identity = new ClaimsIdentity(new List<Claim>
+            return new TokenValidatedContext(
+                new DefaultHttpContext(), 
+                new AuthenticationScheme(",", "", typeof(TestAuthHandler)),
+                new OpenIdConnectOptions(), Mock.Of<ClaimsPrincipal>(),
+                new AuthenticationProperties())
             {
-                new Claim(ClaimName.Sub, userId),
-                new Claim(ClaimTypes.Email, emailAddress),
-                new Claim(ClaimName.Organisation, JsonConvert.SerializeObject(organisation)),
-                new Claim(ClaimName.FamilyName, "Tester"),
-                new Claim(ClaimName.GivenName, "Test")
-            });
-        
-            var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(identity));
-            return new TokenValidatedContext(new DefaultHttpContext(), new AuthenticationScheme(",","", typeof(TestAuthHandler)),
-                new OpenIdConnectOptions(), Mock.Of<ClaimsPrincipal>(), new AuthenticationProperties())
-            {
-                Principal = claimsPrincipal
+                Principal = new ClaimsPrincipal(
+                    new ClaimsIdentity(
+                    new ClaimsIdentity(
+                    new List<Claim>
+                {
+                    new(ClaimName.Sub, userId),
+                    new(ClaimTypes.Email, emailAddress),
+                    new(ClaimName.Organisation, JsonConvert.SerializeObject(organisation)),
+                    new(ClaimName.FamilyName, "Tester"),
+                    new(ClaimName.GivenName, "Test")
+                })))
             };
         }
-    
-    
+
+
         private class TestAuthHandler : IAuthenticationHandler
         {
             public Task InitializeAsync(AuthenticationScheme scheme, HttpContext context)

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Services/DfESignInServiceTest.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Services/DfESignInServiceTest.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json;
 using SFA.DAS.DfESignIn.Auth.Api.Models;
 using SFA.DAS.DfESignIn.Auth.Configuration;
 using SFA.DAS.DfESignIn.Auth.Constants;
+using SFA.DAS.DfESignIn.Auth.Enums;
 using SFA.DAS.DfESignIn.Auth.Interfaces;
 using SFA.DAS.DfESignIn.Auth.Services;
 using SFA.DAS.Testing.AutoFixture;
@@ -38,7 +39,7 @@ namespace SFA.DAS.DfESignIn.Auth.UnitTests.Services
 
             var actualClaims = tokenValidatedContext.Principal?.Identities.First().Claims.ToList();
             actualClaims?.First(c => c.Type.Equals(CustomClaimsIdentity.UkPrn)).Value.Should().Be(organisation.UkPrn.ToString());
-            actualClaims?.First(c => c.Type.Equals(ClaimsIdentity.DefaultNameClaimType)).Value.Should().Be(userId);
+            actualClaims?.First(c => c.Type.Equals(ClaimsIdentity.DefaultNameClaimType)).Value.Should().Be("Test Tester");
             actualClaims?.First(c => c.Type.Equals(ClaimName.Sub)).Value.Should().Be(userId);
             actualClaims?.First(c => c.Type.Equals(CustomClaimsIdentity.DisplayName)).Value.Should().Be("Test Tester");
         }
@@ -54,7 +55,7 @@ namespace SFA.DAS.DfESignIn.Auth.UnitTests.Services
             [Frozen] Mock<ICustomServiceRole> customServiceRole)
         {
             var tokenValidatedContext = ArrangeTokenValidatedContext(userId, organisation, string.Empty);
-            response.Roles = response.Roles.Select(c => {c.Status.Id = 1; return c;}).ToList();
+            response.Roles = response.Roles.Select(c => {c.Status.Id = (int)RoleStatus.Active; return c;}).ToList();
             apiHelper.Setup(x => x.Get<ApiServiceResponse>($"{config.APIServiceUrl}/services/{config.APIServiceId}/organisations/{organisation.Id}/users/{userId}")).ReturnsAsync(response);
             configuration.Setup(c => c.Value).Returns(config);
             customServiceRole.Setup(role => role.RoleClaimType).Returns(CustomClaimsIdentity.Service);

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddAndConfigureDfESignInAuthenticationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddAndConfigureDfESignInAuthenticationExtension.cs
@@ -6,7 +6,13 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
 {
     public static class AddAndConfigureDfESignInAuthenticationExtension
     {
-        public static void AddAndConfigureDfESignInAuthentication(this IServiceCollection services, IConfiguration configuration, string authenticationCookieName, Type customServiceRole, string clientName)
+        public static void AddAndConfigureDfESignInAuthentication(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            string authenticationCookieName,
+            Type customServiceRole,
+            string clientName,
+            string signedOutCallbackPath = "/signed-out")
         {
             services.AddServiceRegistration(configuration, customServiceRole, clientName);
             if (!string.IsNullOrEmpty(configuration["NoAuthEmail"]))
@@ -15,7 +21,7 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
             }
             else
             {
-                services.ConfigureDfESignInAuthentication(configuration, authenticationCookieName, clientName);
+                services.ConfigureDfESignInAuthentication(configuration, authenticationCookieName, clientName, signedOutCallbackPath);
             }
         }
     }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddServiceRegistrationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddServiceRegistrationExtension.cs
@@ -16,7 +16,11 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
 {
     internal static class AddServiceRegistrationExtension
     {
-        internal static void AddServiceRegistration(this IServiceCollection services, IConfiguration configuration, Type customServiceRole, string clientName)
+        internal static void AddServiceRegistration(
+            this IServiceCollection services, 
+            IConfiguration configuration, 
+            Type customServiceRole, 
+            string clientName)
         {
             if (!configuration.GetSection(nameof(DfEOidcConfiguration)).GetChildren().Any())
             {

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInAuthenticationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInAuthenticationExtension.cs
@@ -20,7 +20,8 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
             this IServiceCollection services,
             IConfiguration configuration,
             string authenticationCookieName,
-            string clientName)
+            string clientName,
+            string signedOutCallbackPath)
         {
             services
                 .AddAuthentication(sharedOptions =>
@@ -38,7 +39,7 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
                     options.ResponseType = "code";
                     options.AuthenticationMethod = OpenIdConnectRedirectBehavior.RedirectGet;
                     options.SignedOutRedirectUri = "/";
-                    options.SignedOutCallbackPath = configuration[$"DfEOidcConfiguration_{clientName}:SignedOutCallbackPath"];
+                    options.SignedOutCallbackPath = signedOutCallbackPath;
                     options.CallbackPath = "/sign-in";
                     options.SaveTokens = true;
                     options.GetClaimsFromUserInfoEndpoint = true;

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInAuthenticationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInAuthenticationExtension.cs
@@ -38,7 +38,7 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
                     options.ResponseType = "code";
                     options.AuthenticationMethod = OpenIdConnectRedirectBehavior.RedirectGet;
                     options.SignedOutRedirectUri = "/";
-                    options.SignedOutCallbackPath = "/signed-out";
+                    options.SignedOutCallbackPath = configuration[$"DfEOidcConfiguration_{clientName}:SignedOutCallbackPath"];
                     options.CallbackPath = "/sign-in";
                     options.SaveTokens = true;
                     options.GetClaimsFromUserInfoEndpoint = true;

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Configuration/DfEOidcConfiguration.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Configuration/DfEOidcConfiguration.cs
@@ -8,5 +8,6 @@ namespace SFA.DAS.DfESignIn.Auth.Configuration
         public string APIServiceUrl { get; set; }
         public string APIServiceId { get; set; }
         public string APIServiceSecret { get; set; }
+        public string SignedOutCallbackPath { get; set; } = "/signed-out";
     }
 }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Configuration/DfEOidcConfiguration.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Configuration/DfEOidcConfiguration.cs
@@ -8,6 +8,5 @@ namespace SFA.DAS.DfESignIn.Auth.Configuration
         public string APIServiceUrl { get; set; }
         public string APIServiceId { get; set; }
         public string APIServiceSecret { get; set; }
-        public string SignedOutCallbackPath { get; set; } = "/signed-out";
     }
 }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Enums/CustomServiceRoleValueType.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Enums/CustomServiceRoleValueType.cs
@@ -1,0 +1,15 @@
+﻿namespace SFA.DAS.DfESignIn.Auth.Enums
+{
+    public enum CustomServiceRoleValueType
+    {
+        /// <summary>
+        /// Enum Service Role Value by Name.
+        /// </summary>
+        Name = 0,
+
+        /// <summary>
+        /// Enum Service Role Value by Code.
+        /// </summary>
+        Code = 1
+    }
+}

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Enums/CustomServiceRoleValueType.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Enums/CustomServiceRoleValueType.cs
@@ -5,11 +5,11 @@
         /// <summary>
         /// Enum Service Role Value by Name.
         /// </summary>
-        Name = 0,
+        Name = 1,
 
         /// <summary>
         /// Enum Service Role Value by Code.
         /// </summary>
-        Code = 1
+        Code = 2
     }
 }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Enums/RoleStatus.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Enums/RoleStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace SFA.DAS.DfESignIn.Auth.Enums
+{
+    public enum RoleStatus
+    {
+        InActive = 0,
+        Active = 1,
+    }
+}

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Interfaces/ICustomServiceRole.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Interfaces/ICustomServiceRole.cs
@@ -7,7 +7,7 @@ namespace SFA.DAS.DfESignIn.Auth.Interfaces
         string RoleClaimType { get; }
 
         /// <summary>
-        /// Property defines the custom service role value type when mapping the claims to the identity.
+        /// Property defines the custom service role value type(Name/Code) when mapping the claims to the identity.
         /// </summary>
         CustomServiceRoleValueType RoleValueType { get; }
     }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Interfaces/ICustomServiceRole.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Interfaces/ICustomServiceRole.cs
@@ -1,7 +1,14 @@
-﻿namespace SFA.DAS.DfESignIn.Auth.Interfaces
+﻿using SFA.DAS.DfESignIn.Auth.Enums;
+
+namespace SFA.DAS.DfESignIn.Auth.Interfaces
 {
     public interface ICustomServiceRole
     {
         string RoleClaimType { get; }
+
+        /// <summary>
+        /// Property defines the custom service role value type when mapping the claims to the identity.
+        /// </summary>
+        CustomServiceRoleValueType RoleValueType { get; }
     }
 }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Services/DfESignInService.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Services/DfESignInService.cs
@@ -87,8 +87,6 @@ namespace SFA.DAS.DfESignIn.Auth.Services
                                     ? role.Name
                                     : role.Code));
                 }
-
-                
                 ctx?.Principal?.Identities.First().AddClaims(roleClaims);
             }
         }


### PR DESCRIPTION
Commit Details:
1) Added New Property under ICustomServiceRole to define the Role Name or Code while mapping the Claims to the original identity. 
2) SignedOutCallBack Url Property added to Config
3) Other Minor improvements
4) Unit test amendments for the above changes.

#Story: https://skillsfundingagency.atlassian.net/browse/FAI-853