### PR TITLE
FAI-857 DfESign In - Store Authentication session in Redis

### DIFF
--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Services/AuthenticationTicketStoreTests.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Services/AuthenticationTicketStoreTests.cs
@@ -1,0 +1,89 @@
+﻿using AutoFixture.NUnit3;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
+using Moq;
+using SFA.DAS.Testing.AutoFixture;
+using FluentAssertions;
+using SFA.DAS.DfESignIn.Auth.Configuration;
+using SFA.DAS.DfESignIn.Auth.Services;
+
+namespace SFA.DAS.DfESignIn.Auth.UnitTests.Services
+{
+    public class AuthenticationTicketStoreTests
+    {
+        [Test, MoqAutoData]
+        public async Task Then_The_Ticket_Is_Added_To_The_Store(
+            AuthenticationTicket ticket,
+            int expiryTime,
+            [Frozen] Mock<IDistributedCache> distributedCache,
+            [Frozen] Mock<IOptions<DfEOidcConfiguration>> config,
+            AuthenticationTicketStore authenticationTicketStore)
+        {
+            config.Object.Value.LoginSlidingExpiryTimeOutInMinutes = expiryTime;
+
+            var result = await authenticationTicketStore.StoreAsync(ticket);
+
+            Assert.That(Guid.TryParse(result, out var actualKey), Is.True);
+            distributedCache.Verify(x => x.SetAsync(
+                actualKey.ToString(),
+                It.Is<byte[]>(c => TicketSerializer.Default.Deserialize(c).AuthenticationScheme == ticket.AuthenticationScheme),
+                It.Is<DistributedCacheEntryOptions>(c
+                    => c.SlidingExpiration.Value.Minutes == TimeSpan.FromMinutes(expiryTime).Minutes),
+                It.IsAny<CancellationToken>()
+                ), Times.Once);
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_The_Ticket_Is_Retrieved_By_Id_From_The_Store(
+            AuthenticationTicket ticket,
+            string key,
+            [Frozen] Mock<IDistributedCache> distributedCache,
+            AuthenticationTicketStore authenticationTicketStore)
+        {
+            distributedCache.Setup(x => x.GetAsync(key, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(TicketSerializer.Default.Serialize(ticket));
+
+            var result = await authenticationTicketStore.RetrieveAsync(key);
+
+            result.Should().BeEquivalentTo(ticket);
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_Null_Is_Returned_If_The_Key_Does_Not_Exist(
+            string key,
+            [Frozen] Mock<IDistributedCache> distributedCache,
+            AuthenticationTicketStore authenticationTicketStore)
+        {
+            distributedCache.Setup(x => x.GetAsync(key, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((byte[])null!);
+
+            var result = await authenticationTicketStore.RetrieveAsync(key);
+
+            result.Should().BeNull();
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_The_Key_Is_Refreshed(
+            AuthenticationTicket ticket,
+            string key,
+            [Frozen] Mock<IDistributedCache> distributedCache,
+            AuthenticationTicketStore authenticationTicketStore)
+        {
+            await authenticationTicketStore.RenewAsync(key, ticket);
+
+            distributedCache.Verify(x => x.RefreshAsync(key, CancellationToken.None));
+        }
+
+        [Test, MoqAutoData]
+        public async Task Then_The_Key_Is_Removed(
+            string key,
+            [Frozen] Mock<IDistributedCache> distributedCache,
+            AuthenticationTicketStore authenticationTicketStore)
+        {
+            await authenticationTicketStore.RemoveAsync(key);
+
+            distributedCache.Verify(x => x.RemoveAsync(key, CancellationToken.None));
+        }
+    }
+}

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Services/AuthenticationTicketStoreTests.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Services/AuthenticationTicketStoreTests.cs
@@ -27,9 +27,9 @@ namespace SFA.DAS.DfESignIn.Auth.UnitTests.Services
             Assert.That(Guid.TryParse(result, out var actualKey), Is.True);
             distributedCache.Verify(x => x.SetAsync(
                 actualKey.ToString(),
-                It.Is<byte[]>(c => TicketSerializer.Default.Deserialize(c).AuthenticationScheme == ticket.AuthenticationScheme),
+                It.Is<byte[]>(c => TicketSerializer.Default.Deserialize(c)!.AuthenticationScheme == ticket.AuthenticationScheme),
                 It.Is<DistributedCacheEntryOptions>(c
-                    => c.SlidingExpiration.Value.Minutes == TimeSpan.FromMinutes(expiryTime).Minutes),
+                    => c.SlidingExpiration != null && c.SlidingExpiration.Value.Minutes == TimeSpan.FromMinutes(expiryTime).Minutes),
                 It.IsAny<CancellationToken>()
                 ), Times.Once);
         }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInAuthenticationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInAuthenticationExtension.cs
@@ -90,11 +90,19 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
                 .AddAuthenticationCookie(authenticationCookieName);
             services
                 .AddOptions<OpenIdConnectOptions>(OpenIdConnectDefaults.AuthenticationScheme)
-                .Configure<IDfESignInService, IOptions<DfEOidcConfiguration>>(
-                    (options, dfeSignInService, config) =>
+                .Configure<IDfESignInService, IOptions<DfEOidcConfiguration>, ITicketStore>(
+                    (options, dfeSignInService, config, ticketStore) =>
                     {
                         options.Events.OnTokenValidated = async ctx => await dfeSignInService.PopulateAccountClaims(ctx);
                     });
+            services
+                .AddOptions<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme)
+                .Configure<ITicketStore, DfEOidcConfiguration>((options, ticketStore, config) =>
+                {
+                    options.ExpireTimeSpan = TimeSpan.FromMinutes(config.LoginSlidingExpiryTimeOutInMinutes);
+                    options.SlidingExpiration = true;
+                    options.SessionStore = ticketStore;
+                });
         }
 
     }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Configuration/DfEOidcConfiguration.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Configuration/DfEOidcConfiguration.cs
@@ -8,5 +8,7 @@ namespace SFA.DAS.DfESignIn.Auth.Configuration
         public string APIServiceUrl { get; set; }
         public string APIServiceId { get; set; }
         public string APIServiceSecret { get; set; }
+        public int LoginSlidingExpiryTimeOutInMinutes { get; set; } = 30;
+        public string DfELoginSessionConnectionString { get; set; }
     }
 }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.csproj
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="Azure.Identity" Version="1.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.16" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
 

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.csproj
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="Azure.Identity" Version="1.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
         <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.16" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Services/AuthenticationTicketStore.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Services/AuthenticationTicketStore.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
+using SFA.DAS.DfESignIn.Auth.Configuration;
+
+namespace SFA.DAS.DfESignIn.Auth.Services
+{
+    public class AuthenticationTicketStore : ITicketStore
+    {
+        private readonly DfEOidcConfiguration _configuration;
+        private readonly IDistributedCache _distributedCache;
+
+        public AuthenticationTicketStore(IDistributedCache distributedCache, IOptions<DfEOidcConfiguration> configuration)
+        {
+            _distributedCache = distributedCache;
+            _configuration = configuration.Value;
+        }
+
+        public async Task<string> StoreAsync(AuthenticationTicket ticket)
+        {
+            var key = Guid.NewGuid().ToString();
+            await _distributedCache.SetAsync(key, TicketSerializer.Default.Serialize(ticket), new DistributedCacheEntryOptions
+            {
+                SlidingExpiration = TimeSpan.FromMinutes(_configuration.LoginSlidingExpiryTimeOutInMinutes)
+            });
+            return key;
+        }
+
+        public async Task RenewAsync(string key, AuthenticationTicket ticket)
+        {
+            await _distributedCache.RefreshAsync(key);
+        }
+
+        public async Task<AuthenticationTicket> RetrieveAsync(string key)
+        {
+            var result = await _distributedCache.GetAsync(key);
+            return result == null ? null : TicketSerializer.Default.Deserialize(result);
+        }
+
+        public async Task RemoveAsync(string key)
+        {
+            await _distributedCache.RemoveAsync(key);
+        }
+    }
+}


### PR DESCRIPTION
Commit Details:
Introducing ITicketStore to store the authenticationTicket. 
Store Authentication session in Redis Cache

Story Link: https://skillsfundingagency.atlassian.net/browse/FAI-857