### PR TITLE
FAI-886 Return logged off users to the service start screen

### DIFF
--- a/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/Controllers/HomeController.cs
+++ b/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/Controllers/HomeController.cs
@@ -35,7 +35,9 @@ public class HomeController : Controller
         authenticationProperties.Parameters.Clear();
         authenticationProperties.Parameters.Add("id_token",idToken);
         return SignOut(
-            authenticationProperties, CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme);
+            authenticationProperties,
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            OpenIdConnectDefaults.AuthenticationScheme);
     }
     
 }

--- a/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/Program.cs
+++ b/SFA.DAS.DfESignIn.Auth.Samples/SFA.DAS.DfESignIn.SampleSite/Program.cs
@@ -19,6 +19,7 @@ builder.Services
         options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
     })
     .SetDefaultNavigationSection(NavigationSection.YourCohorts)
+    .SetDfESignInConfiguration(true)
     ;
 
 var app = builder.Build();

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Api/Client/DfeSignInApiHelper.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Api/Client/DfeSignInApiHelper.cs
@@ -1,10 +1,9 @@
 ﻿using Newtonsoft.Json;
+using SFA.DAS.DfESignIn.Auth.Api.Helpers;
 using SFA.DAS.DfESignIn.Auth.Interfaces;
-using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using SFA.DAS.DfESignIn.Auth.Api.Helpers;
 
 namespace SFA.DAS.DfESignIn.Auth.Api.Client
 {

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddAndConfigureDfESignInAuthenticationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/AddAndConfigureDfESignInAuthenticationExtension.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
             services.AddServiceRegistration(configuration, customServiceRole, clientName);
             if (!string.IsNullOrEmpty(configuration["NoAuthEmail"]))
             {
-                services.AddProviderStubAuthentication($"{authenticationCookieName}.stub");
+                services.AddProviderStubAuthentication($"{authenticationCookieName}.stub", signedOutCallbackPath);
             }
             else
             {

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInStubAuthenticationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInStubAuthenticationExtension.cs
@@ -7,9 +7,10 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
 {
     internal static class ConfigureDfESignInStubAuthenticationExtension
     {
-
-        public static void AddProviderStubAuthentication(this IServiceCollection services,
-            string authenticationCookieName)
+        public static void AddProviderStubAuthentication(
+            this IServiceCollection services,
+            string authenticationCookieName,
+            string signedOutCallbackPath)
         {
             services
                 .AddAuthentication(sharedOptions =>
@@ -27,8 +28,7 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
                     };
                 });
 
-            services.AddAuthentication(authenticationCookieName).AddAuthenticationCookie(authenticationCookieName);
+            services.AddAuthentication(authenticationCookieName).AddAuthenticationCookie(authenticationCookieName, signedOutCallbackPath);
         }
-
     }
 }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureSharedAuthenticationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureSharedAuthenticationExtension.cs
@@ -8,20 +8,22 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
 {
     public static class ConfigureSharedAuthenticationExtension
     {
-        public static void AddAuthenticationCookie(this AuthenticationBuilder services,
-            string cookieName)
+        public static void AddAuthenticationCookie(
+            this AuthenticationBuilder services,
+            string cookieName,
+            string signedOutCallbackPath)
         {
-            
             services.AddCookie(options =>
             {
                 options.AccessDeniedPath = new PathString("/error/403");
                 options.ExpireTimeSpan = TimeSpan.FromHours(1);
                 options.Cookie.Name = cookieName;
+                options.Cookie.IsEssential = true;
                 options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
                 options.SlidingExpiration = true;
-                options.Cookie.SameSite = SameSiteMode.None;
+                options.Cookie.SameSite = SameSiteMode.Lax;
                 options.CookieManager = new ChunkingCookieManager { ChunkSize = 3000 };
-                options.LogoutPath = "/home/signed-out";
+                options.LogoutPath = new PathString(signedOutCallbackPath);
             });
         }
     }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.csproj
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.csproj
@@ -33,7 +33,7 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.8" />
         <PackageReference Include="SFA.DAS.Provider.Shared.UI">
-          <Version>2.0.14</Version>
+          <Version>2.0.26</Version>
         </PackageReference>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
Commit Details:
1) Intercept OpenIdConnect Signout Event with OnSignedOutCallbackRedirect option to destroy the OpenIdConnect Cookie and SignOut the User Auth session 
2) Code Clean-up - in the Services.AddCookie Extension class

Story: https://skillsfundingagency.atlassian.net/browse/FAI-886