### PR TITLE
Removing Microsoft.Rest.ClientRuntime package 

### DIFF
--- a/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth.csproj
+++ b/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth.csproj
@@ -21,8 +21,7 @@
         <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.16" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.22.0" />
-        <PackageReference Include="Microsoft.IdentityModel.KeyVaultExtensions" Version="6.22.0" />
-        <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
+        <PackageReference Include="Microsoft.IdentityModel.KeyVaultExtensions" Version="6.32.2" />
         <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
         
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/SFA.DAS.GovUk.Auth.Samples/SFA.DAS.GovUK.SampleSite/SFA.DAS.GovUK.SampleSite.csproj
+++ b/SFA.DAS.GovUk.Auth.Samples/SFA.DAS.GovUK.SampleSite/SFA.DAS.GovUK.SampleSite.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="Azure.Identity" Version="1.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.8" />
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.22.0" />
-        <PackageReference Include="Microsoft.IdentityModel.KeyVaultExtensions" Version="6.22.0" />
+        <PackageReference Include="Microsoft.IdentityModel.KeyVaultExtensions" Version="6.32.2" />
         <PackageReference Include="SFA.DAS.MA.Shared.UI" Version="1.1.79" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.21.0" />
         <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />


### PR DESCRIPTION
 Microsoft.Rest.ClientRuntime version is causing build pipelines to fail during package scanning tasks.