### PR TITLE
FAI-998 - Add new client name enum

### DIFF
--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Extensions/RedirectExtensionTests.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth.UnitTests/Extensions/RedirectExtensionTests.cs
@@ -57,20 +57,21 @@ namespace SFA.DAS.DfESignIn.Auth.UnitTests.Extensions
             actual.Should().Be("test");
         }
 
-        [TestCase("test","test-pas", ClientName.ProviderRoatp)]
-        [TestCase("pp","pp-pas", ClientName.ProviderRoatp)]
-        [TestCase("something","something-pas", ClientName.ProviderRoatp)]
-        [TestCase("test","test-admin", ClientName.ServiceAdmin)]
-        [TestCase("test","test-adminaan", ClientName.ServiceAdminAan)]
-        [TestCase("test","test-support-tools", ClientName.BulkStop)]
-        [TestCase("test","test-identify-data-locks", ClientName.DataLocks)]
-        [TestCase("test","test-review", ClientName.Qa)]
-        [TestCase("test","test-console", ClientName.SupportConsole)]
+        [TestCase("test","test-pas.", ClientName.ProviderRoatp)]
+        [TestCase("pp","pp-pas.", ClientName.ProviderRoatp)]
+        [TestCase("something","something-pas.", ClientName.ProviderRoatp)]
+        [TestCase("test","test-admin.", ClientName.ServiceAdmin)]
+        [TestCase("test","test-adminaan.", ClientName.ServiceAdminAan)]
+        [TestCase("test","test-support-tools.", ClientName.BulkStop)]
+        [TestCase("test","test-identify-data-locks.", ClientName.DataLocks)]
+        [TestCase("test","test-review.", ClientName.Qa)]
+        [TestCase("test","test-console.", ClientName.SupportConsole)]
+        [TestCase("test","",ClientName.RoatpServiceAdmin)]
         public void Then_The_Logged_Out_Url_Is_Returned_For_Test(string environment,string expectedUrlPart, ClientName clientName)
         {
-            var actual = "".GetSignedOutRedirectUrl(environment, clientName);
+            var actual = RedirectExtension.GetEnvironmentAndDomain(environment, clientName);
             
-            actual.Should().Be($"https://{expectedUrlPart}.apprenticeships.education.gov.uk");
+            actual.Should().Be($"{expectedUrlPart}apprenticeships.education.gov.uk");
         }
         
         [TestCase(ClientName.ProviderRoatp, "providers.apprenticeships")]
@@ -80,6 +81,7 @@ namespace SFA.DAS.DfESignIn.Auth.UnitTests.Extensions
         [TestCase(ClientName.DataLocks, "identify-data-locks.apprenticeships")]
         [TestCase(ClientName.BulkStop, "support-tools.apprenticeships")]
         [TestCase(ClientName.SupportConsole, "console.apprenticeships")]
+        [TestCase(ClientName.RoatpServiceAdmin, "admin.apprenticeships")]
         public void Then_The_Logged_Out_Url_Is_Returned_For_Prod_For_Each_Client_Type(ClientName clientName, string expectedUrlPart)
         {
             var actual = "".GetSignedOutRedirectUrl("prd", clientName);

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInAuthenticationExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/AppStart/ConfigureDfESignInAuthenticationExtension.cs
@@ -37,8 +37,13 @@ namespace SFA.DAS.DfESignIn.Auth.AppStart
                 })
                 .AddOpenIdConnect(options =>
                 {
-                    options.ClientId = configuration[$"DfEOidcConfiguration_{clientName}:ClientId"];
-                    options.ClientSecret = configuration[$"DfEOidcConfiguration_{clientName}:Secret"];
+                    var configName = clientName;
+                    if (clientName == ClientName.RoatpServiceAdmin)
+                    {
+                        configName = ClientName.ServiceAdmin;
+                    }
+                    options.ClientId = configuration[$"DfEOidcConfiguration_{configName}:ClientId"];
+                    options.ClientSecret = configuration[$"DfEOidcConfiguration_{configName}:Secret"];
                     options.MetadataAddress = $"{configuration["DfEOidcConfiguration:BaseUrl"]}/.well-known/openid-configuration";
                     options.ResponseType = "code";
                     options.AuthenticationMethod = OpenIdConnectRedirectBehavior.RedirectGet;

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Enums/ClientName.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Enums/ClientName.cs
@@ -19,6 +19,8 @@ namespace SFA.DAS.DfESignIn.Auth.Enums
         [Description("providers|pas")]
         TraineeshipRoatp = 7,
         [Description("adminaan")]
-        ServiceAdminAan = 8
+        ServiceAdminAan = 8,
+        [Description("roatpadmin")]
+        RoatpServiceAdmin = 9,
     }
 }

--- a/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Extensions/RedirectExtension.cs
+++ b/SFA.DAS.DfESignIn.Auth/SFA.DAS.DfESignIn.Auth/Extensions/RedirectExtension.cs
@@ -11,7 +11,12 @@ namespace SFA.DAS.DfESignIn.Auth.Extensions
                 return "";
             }
 
-            var apprenticeshipsEducationGovUk = ".apprenticeships.education.gov.uk";
+            var apprenticeshipsEducationGovUk = "apprenticeships.education.gov.uk";
+            if (clientName == ClientName.RoatpServiceAdmin)
+            {
+                return apprenticeshipsEducationGovUk;
+            }
+            apprenticeshipsEducationGovUk = $".{apprenticeshipsEducationGovUk}";
             if (clientName == ClientName.ProviderRoatp || clientName == ClientName.TraineeshipRoatp)
             {
                 if (clientName == ClientName.TraineeshipRoatp)
@@ -35,8 +40,15 @@ namespace SFA.DAS.DfESignIn.Auth.Extensions
             {
                 return redirectUri;
             }
-
+            
             var environmentAndDomain = GetEnvironmentAndDomain(environment, clientName);
+            
+            if (clientName == ClientName.RoatpServiceAdmin)
+            {
+                environmentAndDomain = GetEnvironmentAndDomain(environment, ClientName.ServiceAdmin);
+            }
+
+            
             return string.IsNullOrEmpty(environmentAndDomain) ? "/" : $"https://{environmentAndDomain}";
         }
     }


### PR DESCRIPTION
Change so that roatpserviceadmin shares config with serviceadmin, but creates a cookie url for all sub sites to share