### PR TITLE
Get Bearer Token set default timeout option for Managed Identity 

### DIFF
--- a/SFA.DAS.Api.Common/SFA.DAS.Api.Common/Infrastructure/AzureClientCredentialHelper.cs
+++ b/SFA.DAS.Api.Common/SFA.DAS.Api.Common/Infrastructure/AzureClientCredentialHelper.cs
@@ -15,7 +15,10 @@ namespace SFA.DAS.Api.Common.Infrastructure
                 {
                     Retry = { NetworkTimeout = TimeSpan.FromSeconds(1), MaxRetries = 2, Delay = TimeSpan.FromMilliseconds(100) }
                 }),
-                new AzureCliCredential());
+                new AzureCliCredential(options: new AzureCliCredentialOptions
+                { 
+                    Retry = { NetworkTimeout = TimeSpan.FromSeconds(1), MaxRetries = 2, Delay = TimeSpan.FromMilliseconds(100) }
+                }));
             
             var accessToken = await azureServiceTokenProvider.GetTokenAsync(new TokenRequestContext(scopes: new[] { identifier }));
 

--- a/SFA.DAS.Api.Common/SFA.DAS.Api.Common/Infrastructure/AzureClientCredentialHelper.cs
+++ b/SFA.DAS.Api.Common/SFA.DAS.Api.Common/Infrastructure/AzureClientCredentialHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
 using SFA.DAS.Api.Common.Interfaces;
@@ -10,10 +11,14 @@ namespace SFA.DAS.Api.Common.Infrastructure
         public async Task<string> GetAccessTokenAsync(string identifier)
         {
             var azureServiceTokenProvider = new ChainedTokenCredential(
-                new ManagedIdentityCredential(),
+                new ManagedIdentityCredential(options: new TokenCredentialOptions
+                {
+                    Retry = { NetworkTimeout = TimeSpan.FromSeconds(1), MaxRetries = 2, Delay = TimeSpan.FromMilliseconds(100) }
+                }),
                 new AzureCliCredential());
-            var accessToken = await azureServiceTokenProvider.GetTokenAsync(new TokenRequestContext(scopes:new[]{identifier}));
-         
+            
+            var accessToken = await azureServiceTokenProvider.GetTokenAsync(new TokenRequestContext(scopes: new[] { identifier }));
+
             return accessToken.Token;
         }
     }

--- a/SFA.DAS.Api.Common/SFA.DAS.Api.Common/Infrastructure/AzureClientCredentialHelper.cs
+++ b/SFA.DAS.Api.Common/SFA.DAS.Api.Common/Infrastructure/AzureClientCredentialHelper.cs
@@ -8,18 +8,30 @@ namespace SFA.DAS.Api.Common.Infrastructure
 {
     public class AzureClientCredentialHelper : IAzureClientCredentialHelper
     {
+        private const int MaxRetries = 2;
+        private readonly TimeSpan _networkTimeout = TimeSpan.FromSeconds(1);
+        private readonly TimeSpan _delay = TimeSpan.FromMilliseconds(100);
+
         public async Task<string> GetAccessTokenAsync(string identifier)
         {
             var azureServiceTokenProvider = new ChainedTokenCredential(
-                new ManagedIdentityCredential(options: new TokenCredentialOptions
-                {
-                    Retry = { NetworkTimeout = TimeSpan.FromSeconds(1), MaxRetries = 2, Delay = TimeSpan.FromMilliseconds(100) }
-                }),
-                new AzureCliCredential(options: new AzureCliCredentialOptions
-                { 
-                    Retry = { NetworkTimeout = TimeSpan.FromSeconds(1), MaxRetries = 2, Delay = TimeSpan.FromMilliseconds(100) }
-                }));
-            
+                    new ManagedIdentityCredential(options: new TokenCredentialOptions
+                    {
+                        Retry = { NetworkTimeout = _networkTimeout, MaxRetries = MaxRetries, Delay = _delay }
+                    }),
+                    new AzureCliCredential(options: new AzureCliCredentialOptions
+                    {
+                        Retry = { NetworkTimeout = _networkTimeout, MaxRetries = MaxRetries, Delay = _delay }
+                    }),
+                    new VisualStudioCredential(options: new VisualStudioCredentialOptions
+                    {
+                        Retry = { NetworkTimeout = _networkTimeout, MaxRetries = MaxRetries, Delay = _delay }
+                    }),
+                    new VisualStudioCodeCredential(options: new VisualStudioCodeCredentialOptions()
+                    {
+                        Retry = { NetworkTimeout = _networkTimeout, MaxRetries = MaxRetries, Delay = _delay }
+                    }));
+
             var accessToken = await azureServiceTokenProvider.GetTokenAsync(new TokenRequestContext(scopes: new[] { identifier }));
 
             return accessToken.Token;

--- a/SFA.DAS.Api.Common/SFA.DAS.Api.Common/SFA.DAS.Api.Common.csproj
+++ b/SFA.DAS.Api.Common/SFA.DAS.Api.Common/SFA.DAS.Api.Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.4.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
Issue: APIM trying to get the Bearer token using ManagedIdentity is taking longer than expected. This issue could be happening only in the local/dev box.

Error: The request was cancelled due to the configured HttpClient.Timeout of 100 seconds elapsing. 

Resolution: Setting default timeout for ManagedIdentityCredentials, If it can't get the token using ManagedIdentity try with AzureCLI.