### PR TITLE
FAI-2427 - Allow version in config row name

### DIFF
--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationProvider.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationProvider.cs
@@ -27,13 +27,13 @@ namespace SFA.DAS.Configuration.AzureTableStorage
             _configurationKeys = configurationKeys;
             _prefixConfigurationKeys = prefixConfigurationKeys;
             _configurationKeysRawJsonResult = configurationKeysRawJsonResult;
-            _configurationTableRowKeyVersion = configurationNameIncludesVersionNumber ? "" : "1.0";
+            _configurationTableRowKeyVersion = configurationNameIncludesVersionNumber ? "" : "_1.0";
         }
         
         public override void Load()
         {
             var tableClient = _client.GetTableClient(ConfigurationTableName);
-            var filter = $"PartitionKey eq '{_environmentName}' and (RowKey eq '{string.Join($"_{_configurationTableRowKeyVersion}' or RowKey eq '",_configurationKeys)}_{_configurationTableRowKeyVersion}')";
+            var filter = $"PartitionKey eq '{_environmentName}' and (RowKey eq '{string.Join($"{_configurationTableRowKeyVersion}' or RowKey eq '",_configurationKeys)}{_configurationTableRowKeyVersion}')";
             var table = tableClient.QueryAsync<TableEntity>(filter: filter);
             var data = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationSource.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/AzureTableStorageConfigurationSource.cs
@@ -11,6 +11,7 @@ namespace SFA.DAS.Configuration.AzureTableStorage
         internal readonly IEnumerable<string> ConfigurationKeys;
         internal readonly IEnumerable<string> ConfigurationKeysRawJsonResult;
         internal readonly bool PrefixConfigurationKeys;
+        internal readonly bool ConfigurationNameIncludesVersionNumber;
 
 
         public AzureTableStorageConfigurationSource(ConfigurationOptions configOptions)
@@ -20,11 +21,12 @@ namespace SFA.DAS.Configuration.AzureTableStorage
             ConfigurationKeys = configOptions.ConfigurationKeys;
             PrefixConfigurationKeys = configOptions.PrefixConfigurationKeys;
             ConfigurationKeysRawJsonResult = configOptions.ConfigurationKeysRawJsonResult;
+            ConfigurationNameIncludesVersionNumber = configOptions.ConfigurationNameIncludesVersionNumber;
         }
 
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return new AzureTableStorageConfigurationProvider( new TableServiceClient(ConnectionString), EnvironmentName, ConfigurationKeys, PrefixConfigurationKeys, ConfigurationKeysRawJsonResult);
+            return new AzureTableStorageConfigurationProvider( new TableServiceClient(ConnectionString), EnvironmentName, ConfigurationKeys, PrefixConfigurationKeys, ConfigurationKeysRawJsonResult, ConfigurationNameIncludesVersionNumber);
         }
     }
 }

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationBuilderExtensions.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationBuilderExtensions.cs
@@ -61,6 +61,7 @@ namespace SFA.DAS.Configuration.AzureTableStorage
                     options.StorageConnectionStringEnvironmentVariableName, configOptions.EnvironmentName);
 
             configOptions.ConfigurationKeysRawJsonResult = options.ConfigurationKeysRawJsonResult;
+            configOptions.ConfigurationNameIncludesVersionNumber = options.ConfigurationNameIncludesVersionNumber;
             
             var configurationSource = new AzureTableStorageConfigurationSource(configOptions);
 

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationOptions.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/ConfigurationOptions.cs
@@ -7,5 +7,6 @@
         public string[] ConfigurationKeys { get; set; }
         public bool PrefixConfigurationKeys { get; set; } = true;
         public string[] ConfigurationKeysRawJsonResult { get ; set ; } = null;
+        public bool ConfigurationNameIncludesVersionNumber { get; set; } = false;
     }
 }

--- a/Configuration/SFA.DAS.Configuration.AzureTableStorage/StorageOptions.cs
+++ b/Configuration/SFA.DAS.Configuration.AzureTableStorage/StorageOptions.cs
@@ -21,5 +21,6 @@ namespace SFA.DAS.Configuration.AzureTableStorage
         public string[] ConfigurationKeys { get; set; }
         public bool PreFixConfigurationKeys { get; set; } = true;
         public string[] ConfigurationKeysRawJsonResult { get ; set ; } = null;
+        public bool ConfigurationNameIncludesVersionNumber { get; set; } = false;
     }
 }

--- a/Configuration/SFA.DAS.Configuration.TestHarness/Program.cs
+++ b/Configuration/SFA.DAS.Configuration.TestHarness/Program.cs
@@ -12,6 +12,7 @@ namespace SFA.DAS.Configuration.TestHarness
                 .AddAzureTableStorage(o =>
                 {
                     o.EnvironmentNameEnvironmentVariableName = "";
+                    o.ConfigurationNameIncludesVersionNumber = false;
                     o.ConfigurationKeys = new[]
                     {
                         "DoesntExist"

--- a/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/AzureTableStorageConfigurationProviderTests.cs
+++ b/Configuration/SFA.DAS.Configuration.UnitTests/AzureTableStorage/AzureTableStorageConfigurationProviderTests.cs
@@ -109,7 +109,7 @@ namespace SFA.DAS.Configuration.UnitTests.AzureTableStorage
     public class TestableAzureTableStorageConfigurationProvider : AzureTableStorageConfigurationProvider
     {
         public TestableAzureTableStorageConfigurationProvider(TableServiceClient client, string environmentName, IEnumerable<string> configurationKeys, IEnumerable<string> rawConfigurationKeys, bool prefixConfigurationKeys = true)
-            : base(client, environmentName, configurationKeys, prefixConfigurationKeys,rawConfigurationKeys)
+            : base(client, environmentName, configurationKeys, prefixConfigurationKeys,rawConfigurationKeys, false)
         {
         } 
         


### PR DESCRIPTION
Change made so that we can have a mix of versions of config defined. This is done by setting the `Options.ConfigurationNameIncludesVersionNumber = true` and then in configuration defining your configuration as `SFA.DAS.MyConfig_1.0,SFA.DAS.MyOtherConfig_2.0`