### PR TITLE
FAI-2465 - Ensure code_verifier is passed with GetToken

### DIFF
--- a/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth.UnitTests/Services/OidcService/WhenGettingToken.cs
+++ b/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth.UnitTests/Services/OidcService/WhenGettingToken.cs
@@ -58,8 +58,9 @@ public class WhenGettingToken
     }
 
     [Test, MoqAutoData]
-    public async Task Then_The_OpenIdConnectMessage_And_Client_Assertion_Are_Passed_As_Form_Encoded_Content(
+    public async Task Then_The_OpenIdConnectMessage_And_Client_Assertion_Are_Passed_As_Form_Encoded_Content_Along_With_The_CodeVerifier(
         string clientAssertion,
+        string codeVerifier,
         Token token,
         OpenIdConnectMessage openIdConnectMessage,
         GovUkOidcConfiguration config)
@@ -71,6 +72,7 @@ public class WhenGettingToken
             Content = new StringContent(JsonSerializer.Serialize(token)),
             StatusCode = HttpStatusCode.Accepted
         };
+        openIdConnectMessage.Parameters.Add("code_verifier", codeVerifier);
         
         var expectedUrl = new Uri($"{config.BaseUrl}/token");
         var httpMessageHandler = MessageHandler.SetupMessageHandlerMock(response, expectedUrl, HttpMethod.Post);
@@ -102,6 +104,7 @@ public class WhenGettingToken
                     && c.Content.ReadAsStringAsync().Result.Contains($"redirect_uri={openIdConnectMessage.RedirectUri}", StringComparison.CurrentCultureIgnoreCase)
                     && c.Content.ReadAsStringAsync().Result.Contains($"code={openIdConnectMessage.Code}", StringComparison.CurrentCultureIgnoreCase)
                     && c.Content.ReadAsStringAsync().Result.Contains($"client_assertion={clientAssertion}", StringComparison.CurrentCultureIgnoreCase)
+                    && c.Content.ReadAsStringAsync().Result.Contains($"code_verifier={codeVerifier}", StringComparison.CurrentCultureIgnoreCase)
                 ),
                 ItExpr.IsAny<CancellationToken>()
             );

--- a/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/Services/OidcService.cs
+++ b/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/Services/OidcService.cs
@@ -65,13 +65,14 @@ internal class OidcService : IOidcService
 
         httpRequestMessage.Content = new FormUrlEncodedContent(new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("grant_type", "authorization_code"),
-            new KeyValuePair<string, string>("code", openIdConnectMessage?.Code ?? ""),
-            new KeyValuePair<string, string>("redirect_uri", openIdConnectMessage?.RedirectUri ?? ""),
-            new KeyValuePair<string, string>("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"),
-            new KeyValuePair<string, string>("client_assertion", CreateJwtAssertion()),
+            new("grant_type", "authorization_code"),
+            new("code", openIdConnectMessage?.Code ?? ""),
+            new("redirect_uri", openIdConnectMessage?.RedirectUri ?? ""),
+            new("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"),
+            new("client_assertion", CreateJwtAssertion()),
+            new("code_verifier", openIdConnectMessage != null && openIdConnectMessage.Parameters.ContainsKey("code_verifier")?openIdConnectMessage?.Parameters["code_verifier"]:"")
         });
-
+        
         httpRequestMessage.Content.Headers.Clear();
         httpRequestMessage.Content.Headers.Add("Content-Type", "application/x-www-form-urlencoded");
 

--- a/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/Services/OidcService.cs
+++ b/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/Services/OidcService.cs
@@ -70,7 +70,7 @@ internal class OidcService : IOidcService
             new("redirect_uri", openIdConnectMessage?.RedirectUri ?? ""),
             new("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"),
             new("client_assertion", CreateJwtAssertion()),
-            new("code_verifier", openIdConnectMessage != null && openIdConnectMessage.Parameters.ContainsKey("code_verifier")?openIdConnectMessage?.Parameters["code_verifier"]:"")
+            new("code_verifier", openIdConnectMessage != null && openIdConnectMessage.Parameters.TryGetValue("code_verifier", out var codeVerifier) ? codeVerifier : "" )
         });
         
         httpRequestMessage.Content.Headers.Clear();


### PR DESCRIPTION
We have UsePkce enabled, but due to how we have a custom GetToken implementation this was not being passed with the request. This change now passes the code_verifier parameter with that request