### PR TITLE
FAI-2465 Package update

### DIFF
--- a/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth.csproj
+++ b/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth.csproj
@@ -15,21 +15,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Identity" Version="1.13.1" />
+        <PackageReference Include="Azure.Identity" Version="1.13.2" />
         <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
         <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
-        <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.15" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.3.0" />
+        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.8.0" />
         <PackageReference Include="Microsoft.IdentityModel.KeyVaultExtensions" Version="7.7.1" />
+        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.8.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="System.Drawing.Common" Version="8.0.11" />
         <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
         
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.15" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.15" />
 
     </ItemGroup>
     

--- a/SFA.DAS.GovUk.Auth.Samples/SFA.DAS.GovUK.SampleSite/SFA.DAS.GovUK.SampleSite.csproj
+++ b/SFA.DAS.GovUk.Auth.Samples/SFA.DAS.GovUK.SampleSite/SFA.DAS.GovUK.SampleSite.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.21" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.15" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\SFA.DAS.GovUK.Auth\SFA.DAS.GovUK.Auth\SFA.DAS.GovUK.Auth.csproj" />


### PR DESCRIPTION
Added the following package:

```
<PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.8.0" />
```

so that the incorrect version stops being implicitly referenced and stopping the well-known configuration from being correctly loaded