### PR TITLE
FAI-2517

### DIFF
--- a/SFA.DAS.Common/SFA.DAS.Common.Domain/Models/VacancyReference.cs
+++ b/SFA.DAS.Common/SFA.DAS.Common.Domain/Models/VacancyReference.cs
@@ -23,7 +23,7 @@ namespace SFA.DAS.Common.Domain.Models
         private bool IsNone => Value == 0;
 
         public static readonly VacancyReference None = new VacancyReference(string.Empty);
-        private long Value { get; }
+        public long Value { get; }
 
         public VacancyReference(string value)
         {

--- a/SFA.DAS.Testing/SFA.DAS.Testing.AutoFixture/FixtureBuilder.cs
+++ b/SFA.DAS.Testing/SFA.DAS.Testing.AutoFixture/FixtureBuilder.cs
@@ -11,6 +11,8 @@ public static class FixtureBuilder
         var fixture = new Fixture();
         fixture
             .Customize(new AutoMoqCustomization { ConfigureMembers = true });
+        fixture
+            .Customize(new ValidVacancyReferenceCustomization());
 
         return fixture;
     }

--- a/SFA.DAS.Testing/SFA.DAS.Testing.AutoFixture/SFA.DAS.Testing.AutoFixture.csproj
+++ b/SFA.DAS.Testing/SFA.DAS.Testing.AutoFixture/SFA.DAS.Testing.AutoFixture.csproj
@@ -14,6 +14,7 @@
     <ItemGroup>
         <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
         <PackageReference Include="AutoFixture.NUnit3" Version="4.18.1" />
+        <PackageReference Include="SFA.DAS.Common.Domain" Version="1.4.301" />
     </ItemGroup>
 
     <!-- Transitive -->

--- a/SFA.DAS.Testing/SFA.DAS.Testing.AutoFixture/ValidVacancyReferenceCustomization.cs
+++ b/SFA.DAS.Testing/SFA.DAS.Testing.AutoFixture/ValidVacancyReferenceCustomization.cs
@@ -1,4 +1,5 @@
-﻿using AutoFixture;
+﻿using System;
+using AutoFixture;
 using SFA.DAS.Common.Domain.Models;
 
 namespace SFA.DAS.Testing.AutoFixture
@@ -7,7 +8,9 @@ namespace SFA.DAS.Testing.AutoFixture
     {
         public void Customize(IFixture fixture)
         {
-            fixture.Register(() => new VacancyReference("VAC1234567890"));
+            var random = new Random();
+            string number = random.Next(1000000000, int.MaxValue).ToString()[..10];
+            fixture.Register(() => new VacancyReference($"VAC{number}"));
         }
     }
 }

--- a/SFA.DAS.Testing/SFA.DAS.Testing.AutoFixture/ValidVacancyReferenceCustomization.cs
+++ b/SFA.DAS.Testing/SFA.DAS.Testing.AutoFixture/ValidVacancyReferenceCustomization.cs
@@ -1,0 +1,13 @@
+﻿using AutoFixture;
+using SFA.DAS.Common.Domain.Models;
+
+namespace SFA.DAS.Testing.AutoFixture
+{
+    public class ValidVacancyReferenceCustomization : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Register(() => new VacancyReference("VAC1234567890"));
+        }
+    }
+}


### PR DESCRIPTION
✨ Update VacancyReference class for improved accessibility

- Changed `Value` property from private to public.
- Introduced private boolean property `IsNone` for value checks.
- Static readonly instance `None` remains unchanged.
- Enhanced accessibility of the `Value` property.
- Improved code clarity and maintainability.

Changes made by Balaji Jambulingam