### PR TITLE
FAI-3381 - Update to code exchange to encode request

### DIFF
--- a/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth.UnitTests/AppStart/GovUkOpenIdConnectEventsTests.cs
+++ b/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth.UnitTests/AppStart/GovUkOpenIdConnectEventsTests.cs
@@ -298,7 +298,7 @@ namespace SFA.DAS.GovUK.Auth.UnitTests.AppStart
         }
 
 
-        private RedirectContext BuildRedirectContext(
+        private static RedirectContext BuildRedirectContext(
             AuthenticationProperties? properties = null,
             OpenIdConnectMessage? protocolMessage = null,
             ISecureDataFormat<AuthenticationProperties>? stateDataFormat = null,

--- a/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth.UnitTests/AppStart/GovUkOpenIdConnectEventsTests.cs
+++ b/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth.UnitTests/AppStart/GovUkOpenIdConnectEventsTests.cs
@@ -1,11 +1,13 @@
-﻿using System.Security.Claims;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
 using Moq;
 using SFA.DAS.GovUK.Auth.AppStart;
 using SFA.DAS.GovUK.Auth.Configuration;
@@ -20,6 +22,7 @@ namespace SFA.DAS.GovUK.Auth.UnitTests.AppStart
     {
         private Mock<IGovUkAuthenticationService> _authServiceMock;
         private Mock<ICoreIdentityJwtValidator> _jwtValidatorMock;
+        private Mock<ISigningCredentialsProvider> _signingCredentialsProvider;
         private GovUkOidcConfiguration _config;
         private Mock<IOptions<GovUkOidcConfiguration>> _configMock;
         private GovUkOpenIdConnectEvents _sut;
@@ -31,6 +34,8 @@ namespace SFA.DAS.GovUK.Auth.UnitTests.AppStart
         {
             _config = new GovUkOidcConfiguration
             {
+                ClientId = "test-client-id",
+                BaseUrl = "https://oidc.example.gov.uk",
                 RequestedUserInfoClaims = "CoreIdentityJWT,Address"
             };
             _configMock = new Mock<IOptions<GovUkOidcConfiguration>>();
@@ -38,8 +43,23 @@ namespace SFA.DAS.GovUK.Auth.UnitTests.AppStart
 
             _authServiceMock = new Mock<IGovUkAuthenticationService>();
             _jwtValidatorMock = new Mock<ICoreIdentityJwtValidator>();
+            _signingCredentialsProvider = new Mock<ISigningCredentialsProvider>();
 
-            _sut = new GovUkOpenIdConnectEvents(_configMock.Object, _authServiceMock.Object, _jwtValidatorMock.Object, RedirectUrl, SuspendedUrl);
+            var rsa = RSA.Create(2048);
+            var testSigningCredentials = new SigningCredentials(
+                new RsaSecurityKey(rsa),
+                SecurityAlgorithms.RsaSha256);
+            _signingCredentialsProvider
+                .Setup(x => x.GetSigningCredentials())
+                .Returns(testSigningCredentials);
+
+            _sut = new GovUkOpenIdConnectEvents(
+                _configMock.Object,
+                _authServiceMock.Object,
+                _jwtValidatorMock.Object,
+                _signingCredentialsProvider.Object,
+                RedirectUrl,
+                SuspendedUrl);
         }
 
         [Test]
@@ -50,7 +70,7 @@ namespace SFA.DAS.GovUK.Auth.UnitTests.AppStart
                 new AuthenticationScheme("oidc", null, typeof(OpenIdConnectHandler)),
                 new OpenIdConnectOptions(),
                 new Exception("Correlation failed"));
-            
+
             await _sut.RemoteFailure(context);
 
             context.Response.StatusCode.Should().Be(302);
@@ -66,26 +86,122 @@ namespace SFA.DAS.GovUK.Auth.UnitTests.AppStart
                 ["enableVerify"] = "true"
             });
 
-            var protocolMessage = new OpenIdConnectMessage();
+            var context = BuildRedirectContext(properties);
+
+            await _sut.RedirectToIdentityProvider(context);
+
+            context.ProtocolMessage.Parameters["vtr"].Should().NotBeNull();
+            context.ProtocolMessage.Parameters["claims"].Should().Contain("userinfo");
+        }
+
+        [Test]
+        public async Task RedirectToIdentityProvider_SetsJarRequestParameter()
+        {
+            var context = BuildRedirectContext();
+
+            await _sut.RedirectToIdentityProvider(context);
+
+            context.ProtocolMessage.Parameters.Should().ContainKey("request");
+            context.ProtocolMessage.Parameters["request"].Should().NotBeNullOrEmpty();
+        }
+
+        [Test]
+        public async Task RedirectToIdentityProvider_JarContainsCoreAuthorizationClaims()
+        {
+            var message = new OpenIdConnectMessage
+            {
+                ResponseType = "code",
+                ClientId = "test-client-id",
+                RedirectUri = "https://localhost/sign-in",
+                Scope = "openid email",
+                Nonce = "test-nonce"
+            };
+            message.Parameters.Add("vtr", "[\"Cl.Cm\"]");
+
+            var context = BuildRedirectContext(protocolMessage: message);
+
+            await _sut.RedirectToIdentityProvider(context);
+
+            var jwt = ReadJar(context);
+            jwt.Payload["response_type"].Should().Be("code");
+            jwt.Payload["client_id"].Should().Be("test-client-id");
+            jwt.Payload["redirect_uri"].Should().Be("https://localhost/sign-in");
+            jwt.Payload["nonce"].Should().Be("test-nonce");
+            jwt.Payload["ui_locales"].Should().Be("en");
+        }
+
+        [Test]
+        public async Task RedirectToIdentityProvider_JarStateMatchesProtectedProperties()
+        {
+            var context = BuildRedirectContext(stateFormatResult: "expected-protected-state");
+
+            await _sut.RedirectToIdentityProvider(context);
+
+            var jwt = ReadJar(context);
+            jwt.Payload["state"].Should().Be("expected-protected-state");
+        }
+
+        [Test]
+        public async Task RedirectToIdentityProvider_JarStateIsProtectedWithRedirectUriKeyInProperties()
+        {
+            const string callbackUri = "https://localhost/sign-in";
+            AuthenticationProperties? capturedProperties = null;
 
             var mockStateFormat = new Mock<ISecureDataFormat<AuthenticationProperties>>();
             mockStateFormat
                 .Setup(m => m.Protect(It.IsAny<AuthenticationProperties>()))
-                .Returns("mock-protected-state");
+                .Callback<AuthenticationProperties>(p => capturedProperties = p)
+                .Returns("mock-state");
 
-            var context = new RedirectContext(
-                new DefaultHttpContext(),
-                new AuthenticationScheme("oidc", null, typeof(OpenIdConnectHandler)),
-                new OpenIdConnectOptions { StateDataFormat = mockStateFormat.Object },
-                properties)
-            {
-                ProtocolMessage = protocolMessage
-            };
+            var message = new OpenIdConnectMessage { RedirectUri = callbackUri };
+            message.Parameters.Add("vtr", "[\"Cl.Cm\"]");
+
+            var context = BuildRedirectContext(protocolMessage: message, stateDataFormat: mockStateFormat.Object);
 
             await _sut.RedirectToIdentityProvider(context);
 
-            protocolMessage.Parameters["vtr"].Should().NotBeNull();
-            protocolMessage.Parameters["claims"].Should().Contain("userinfo");
+            capturedProperties.Should().NotBeNull();
+            capturedProperties!.Items.Should().ContainKey(OpenIdConnectDefaults.RedirectUriForCodePropertiesKey);
+            capturedProperties.Items[OpenIdConnectDefaults.RedirectUriForCodePropertiesKey].Should().Be(callbackUri);
+        }
+
+        [Test]
+        public async Task RedirectToIdentityProvider_DoesNotSetProtocolMessageState_SoThatJARAndQueryStringStateAreIdentical()
+        {
+            var context = BuildRedirectContext();
+
+            await _sut.RedirectToIdentityProvider(context);
+
+            context.ProtocolMessage.State.Should().BeNull();
+        }
+
+        [Test]
+        public async Task RedirectToIdentityProvider_JarIncludesPkceClaimsWhenPresent()
+        {
+            var message = new OpenIdConnectMessage { RedirectUri = "https://localhost/sign-in" };
+            message.Parameters.Add("vtr", "[\"Cl.Cm\"]");
+            message.Parameters.Add("code_challenge", "abc123challenge");
+            message.Parameters.Add("code_challenge_method", "S256");
+
+            var context = BuildRedirectContext(protocolMessage: message);
+
+            await _sut.RedirectToIdentityProvider(context);
+
+            var jwt = ReadJar(context);
+            jwt.Payload["code_challenge"].Should().Be("abc123challenge");
+            jwt.Payload["code_challenge_method"].Should().Be("S256");
+        }
+
+        [Test]
+        public async Task RedirectToIdentityProvider_JarExcludesPkceClaimsWhenAbsent()
+        {
+            var context = BuildRedirectContext();
+
+            await _sut.RedirectToIdentityProvider(context);
+
+            var jwt = ReadJar(context);
+            jwt.Payload.ContainsKey("code_challenge").Should().BeFalse();
+            jwt.Payload.ContainsKey("code_challenge_method").Should().BeFalse();
         }
 
         [Test]
@@ -144,7 +260,6 @@ namespace SFA.DAS.GovUK.Auth.UnitTests.AppStart
         [Test]
         public async Task SignedOutCallbackRedirect_DeletesCookieAndRedirects()
         {
-            // Arrange
             var cookiesMock = new Mock<IResponseCookies>();
             var responseMock = new Mock<HttpResponse>();
             var contextMock = new Mock<HttpContext>();
@@ -162,14 +277,11 @@ namespace SFA.DAS.GovUK.Auth.UnitTests.AppStart
                 new OpenIdConnectOptions(),
                 new OpenIdConnectMessage());
 
-            // Act
             await _sut.SignedOutCallbackRedirect(context);
 
-            // Assert
             headers["Location"].ToString().Should().Be(RedirectUrl);
             cookiesMock.Verify(c => c.Delete(GovUkConstants.AuthCookieName), Times.Once);
         }
-
 
         [Test]
         public async Task TokenValidated_CallsPopulateAccountClaims()
@@ -183,6 +295,49 @@ namespace SFA.DAS.GovUK.Auth.UnitTests.AppStart
             await _sut.TokenValidated(context);
 
             _authServiceMock.Verify(x => x.PopulateAccountClaims(context), Times.Once);
+        }
+
+
+        private RedirectContext BuildRedirectContext(
+            AuthenticationProperties? properties = null,
+            OpenIdConnectMessage? protocolMessage = null,
+            ISecureDataFormat<AuthenticationProperties>? stateDataFormat = null,
+            string stateFormatResult = "mock-protected-state")
+        {
+            properties ??= new AuthenticationProperties();
+
+            if (protocolMessage == null)
+            {
+                protocolMessage = new OpenIdConnectMessage
+                {
+                    RedirectUri = "https://localhost/sign-in"
+                };
+                protocolMessage.Parameters.Add("vtr", "[\"Cl.Cm\"]");
+            }
+
+            if (stateDataFormat == null)
+            {
+                var mockStateFormat = new Mock<ISecureDataFormat<AuthenticationProperties>>();
+                mockStateFormat
+                    .Setup(m => m.Protect(It.IsAny<AuthenticationProperties>()))
+                    .Returns(stateFormatResult);
+                stateDataFormat = mockStateFormat.Object;
+            }
+
+            return new RedirectContext(
+                new DefaultHttpContext(),
+                new AuthenticationScheme("oidc", null, typeof(OpenIdConnectHandler)),
+                new OpenIdConnectOptions { StateDataFormat = stateDataFormat },
+                properties)
+            {
+                ProtocolMessage = protocolMessage
+            };
+        }
+
+        private static JwtSecurityToken ReadJar(RedirectContext context)
+        {
+            var jarToken = context.ProtocolMessage.Parameters["request"];
+            return new JwtSecurityTokenHandler().ReadJwtToken(jarToken);
         }
     }
 }

--- a/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/AppStart/ConfigureGovUkAuthenticationExtension.cs
+++ b/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/AppStart/ConfigureGovUkAuthenticationExtension.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -23,12 +23,14 @@ namespace SFA.DAS.GovUK.Auth.AppStart
             {
                 var config = sp.GetRequiredService<IOptions<GovUkOidcConfiguration>>();
                 var govUkAuthenticationService = sp.GetRequiredService<IGovUkAuthenticationService>();
-                var coreIdentityJwtValidator = sp.GetRequiredService <ICoreIdentityJwtValidator>();
+                var coreIdentityJwtValidator = sp.GetRequiredService<ICoreIdentityJwtValidator>();
+                var signingCredentialsProvider = sp.GetRequiredService<ISigningCredentialsProvider>();
 
                 return new GovUkOpenIdConnectEvents(
                     config,
                     govUkAuthenticationService,
                     coreIdentityJwtValidator,
+                    signingCredentialsProvider,
                     signedOutRedirectUrl,
                     suspendedRedirectUrl);
             });

--- a/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/AppStart/GovUkOpenIdConnectEvents.cs
+++ b/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/AppStart/GovUkOpenIdConnectEvents.cs
@@ -1,11 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Newtonsoft.Json.Linq;
 using SFA.DAS.GovUK.Auth.Configuration;
 using SFA.DAS.GovUK.Auth.Extensions;
 using SFA.DAS.GovUK.Auth.Models;
@@ -19,6 +21,7 @@ namespace SFA.DAS.GovUK.Auth.AppStart
         private readonly GovUkOidcConfiguration _config;
         private readonly IGovUkAuthenticationService _govUkAuthenticationService;
         private readonly ICoreIdentityJwtValidator _jwtValidator;
+        private readonly ISigningCredentialsProvider _signingCredentialsProvider;
         private readonly string _signedOutRedirectUrl;
         private readonly string _suspendedRedirectUrl;
 
@@ -26,12 +29,14 @@ namespace SFA.DAS.GovUK.Auth.AppStart
             IOptions<GovUkOidcConfiguration> config,
             IGovUkAuthenticationService govUkAuthenticationService,
             ICoreIdentityJwtValidator coreIdentityJwtValidator,
+            ISigningCredentialsProvider signingCredentialsProvider,
             string signedOutRedirectUrl,
             string suspendedRedirectUrl)
         {
             _config = config.Value;
             _govUkAuthenticationService = govUkAuthenticationService;
             _jwtValidator = coreIdentityJwtValidator;
+            _signingCredentialsProvider = signingCredentialsProvider;
             _signedOutRedirectUrl = signedOutRedirectUrl;
             _suspendedRedirectUrl = suspendedRedirectUrl;
         }
@@ -90,12 +95,60 @@ namespace SFA.DAS.GovUK.Auth.AppStart
                 context.ProtocolMessage.Parameters.Add("claims", JsonSerializer.Serialize(claims));
             }
 
-            if (context.ProtocolMessage.State == null)
+            var jarState = context.Options.StateDataFormat.Protect(
+                new AuthenticationProperties(new Dictionary<string, string>(context.Properties.Items))
             {
-                context.ProtocolMessage.State = context.Options.StateDataFormat.Protect(context.Properties);
+                Items =
+                {
+                    [OpenIdConnectDefaults.RedirectUriForCodePropertiesKey] = context.ProtocolMessage.RedirectUri
+                }
+            });
+
+            context.ProtocolMessage.Parameters["request"] = CreateJarRequestObject(context, jarState);
+            return Task.CompletedTask;
+        }
+
+        private string CreateJarRequestObject(RedirectContext context, string state)
+        {
+            var msg = context.ProtocolMessage;
+            var now = DateTime.UtcNow;
+
+            var payload = new JwtPayload(
+                issuer: _config.ClientId,
+                audience: OneLoginUrlHelper.GetJarAudience(_config.BaseUrl),
+                claims: null,
+                notBefore: now,
+                expires: now.AddMinutes(5),
+                issuedAt: now)
+            {
+                ["response_type"] = msg.ResponseType,
+                ["client_id"] = msg.ClientId,
+                ["redirect_uri"] = msg.RedirectUri,
+                ["scope"] = msg.Scope,
+                ["state"] = state,
+                ["nonce"] = msg.Nonce,
+                ["ui_locales"] = "en"
+            };
+
+            if (msg.Parameters.TryGetValue("vtr", out var vtrJson))
+            {
+                payload["vtr"] = JArray.Parse(vtrJson);
+            }
+            if (msg.Parameters.TryGetValue("claims", out var claimsJson))
+            {
+                payload["claims"] = JObject.Parse(claimsJson);
+            }
+            if (msg.Parameters.TryGetValue("code_challenge", out var codeChallenge))
+            {
+                payload["code_challenge"] = codeChallenge;
+            }
+            if (msg.Parameters.TryGetValue("code_challenge_method", out var codeChallengeMethod))
+            {
+                payload["code_challenge_method"] = codeChallengeMethod;
             }
 
-            return Task.CompletedTask;
+            var header = new JwtHeader(_signingCredentialsProvider.GetSigningCredentials());
+            return new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(header, payload));
         }
 
         public override async Task TokenResponseReceived(TokenResponseReceivedContext context)

--- a/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/Configuration/OneLoginUrlHelper.cs
+++ b/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/Configuration/OneLoginUrlHelper.cs
@@ -25,6 +25,13 @@ namespace SFA.DAS.GovUK.Auth.Configuration
             return $"{baseUrl}/".Replace("oidc", "identity");
         }
 
+        internal static string GetJarAudience(string baseUrl)
+        {
+            ArgumentNullException.ThrowIfNull(baseUrl);
+
+            return $"{baseUrl}/authorize";
+        }
+
         internal static string GetDidEndpoint(string baseUrl)
         {
             ArgumentNullException.ThrowIfNull(baseUrl);

--- a/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/Services/AzureKeyVaultSigningCredentialsProvider.cs
+++ b/SFA.DAS.GovUK.Auth/SFA.DAS.GovUK.Auth/Services/AzureKeyVaultSigningCredentialsProvider.cs
@@ -13,7 +13,7 @@ namespace SFA.DAS.GovUK.Auth.Services
         {
             var config = options.Value;
             var key = new KeyVaultSecurityKey(config.KeyVaultIdentifier, identityService.AuthenticationCallback);
-            _cached = new SigningCredentials(key, SecurityAlgorithms.RsaSha512)
+            _cached = new SigningCredentials(key, SecurityAlgorithms.RsaSha256)
             {
                 CryptoProviderFactory = new CryptoProviderFactory { CustomCryptoProvider = new CustomKeyVaultCryptoProvider() }
             };


### PR DESCRIPTION
Further security update so that the request in the initial code is also signed and encoded as JWT security token